### PR TITLE
Check that Stylespace covers all values used by instances

### DIFF
--- a/tests/data/TestIncomplete.stylespace
+++ b/tests/data/TestIncomplete.stylespace
@@ -1,0 +1,93 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>axes</key>
+    <array>
+      <dict>
+        <key>name</key>
+        <string>Weight</string>
+        <key>tag</key>
+        <string>wght</string>
+        <key>locations</key>
+        <array>
+
+          <dict>
+            <key>name</key>
+            <string>XLight</string>
+            <key>value</key>
+            <integer>200</integer>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <string>Light</string>
+            <key>value</key>
+            <integer>300</integer>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <string>Semi Bold</string>
+            <key>value</key>
+            <integer>600</integer>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <dict>
+              <key>en</key>
+              <string>Bold</string>
+            </dict>
+            <key>value</key>
+            <integer>700</integer>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <string>Black</string>
+            <key>value</key>
+            <integer>900</integer>
+            <key>range</key>
+            <array>
+              <integer>701</integer>
+              <integer>900</integer>
+            </array>
+          </dict>
+
+        </array>
+      </dict>
+
+      <dict>
+        <key>name</key>
+        <string>Italic</string>
+        <key>tag</key>
+        <string>ital</string>
+        <key>locations</key>
+        <array>
+
+          <dict>
+            <key>name</key>
+            <string>Upright</string>
+            <key>value</key>
+            <integer>0</integer>
+            <key>linked_value</key>
+            <integer>1</integer>
+            <key>flags</key>
+            <array>
+              <string>ElidableAxisValueName</string>
+            </array>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <string>Italic</string>
+            <key>value</key>
+            <integer>1</integer>
+          </dict>
+
+        </array>
+      </dict>
+    </array>
+  </dict>
+</plist>

--- a/tests/test_make_stat.py
+++ b/tests/test_make_stat.py
@@ -20,6 +20,25 @@ def test_load_stylespace_no_format4(datadir):
     statmake.classes.Stylespace.from_file(datadir / "TestNoFormat4.stylespace")
 
 
+def test_generation_incomplete_stylespace(datadir):
+    with pytest.raises(ValueError, match=r".* no Stylespace entry .*"):
+        _ = testutil.generate_variable_font(
+            datadir / "Test_Wght_Italic.designspace",
+            datadir / "TestIncomplete.stylespace",
+        )
+
+
+def test_generation_incomplete_additional_location(datadir):
+    with pytest.raises(
+        ValueError, match=r".* no Stylespace entry .* additional locations.*"
+    ):
+        _ = testutil.generate_variable_font(
+            datadir / "Test_Wght_Italic.designspace",
+            datadir / "Test.stylespace",
+            {"Italic": 2},
+        )
+
+
 def test_generation_full(datadir):
     varfont = testutil.generate_variable_font(
         datadir / "Test_WghtItal.designspace", datadir / "Test.stylespace"

--- a/tests/testutil.py
+++ b/tests/testutil.py
@@ -89,7 +89,7 @@ def reload_font(font):
 
 
 def generate_variable_font(
-    designspace_path: Path, stylespace_path: Path
+    designspace_path: Path, stylespace_path: Path, additional_locations=None
 ) -> fontTools.ttLib.TTFont:
     designspace = fontTools.designspaceLib.DesignSpaceDocument.fromfile(
         designspace_path
@@ -100,7 +100,10 @@ def generate_variable_font(
     varfont, _, _ = fontTools.varLib.build(designspace)
 
     stylespace = statmake.classes.Stylespace.from_file(stylespace_path)
-    additional_locations = designspace.lib.get("org.statmake.additionalLocations", {})
+    if additional_locations is None:
+        additional_locations = designspace.lib.get(
+            "org.statmake.additionalLocations", {}
+        )
     statmake.lib.apply_stylespace_to_variable_font(
         stylespace, varfont, additional_locations
     )


### PR DESCRIPTION
This covers sanity checking for formats 1, 2 and 3.

Format 4 may need some additional logic. They are supposed to mark instances in the `fvar` table, but there's nothing marking _those_ as named instances. Maybe logging information about which entries make it into the font would help.