### PR TITLE
Add ability to inline Stylespace data into Designspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,31 @@ pip3 install statmake
 
 ## Usage
 
-1. Write a Stylespace file that describes each stop of all axes available in the entire family. See [tests/data/Test.stylespace](tests/data/Test.stylespace) for an annotated example.
-2. If you have one or more Designspace files which do not define all axes available to the family, you have to annotate them with the missing axis locations to get a complete `STAT` table. See the lib key at the bottom of [tests/data/Test_Wght_Upright.designspace](tests/data/Test_Wght_Upright.designspace) and [tests/data/Test_Wght_Italic.designspace](tests/data/Test_Wght_Italic.designspace) for an example.
-3. Generate the variable font(s) as normal
-4. Run `statmake your.stylespace variable_font.designspace variable_font.ttf`. Take care to use the Designspace file that was used to generate the font to get the correct missing axis location definitions.
 
-### Q: Can I please have something other than a .plist file?
+### External Stylespace file, stand-alone or referenced from a Designspace file
+
+If you are producing more than one variable font (i.e. you have multiple Designspace files), you can avoid duplicated information by writing a single all-encompassing Stylespace file which statmake will subset for each variable font.
+
+**Attention:** A `STAT` table is supposed to describe a font's relationship to the _entire_ family. If you have separate upright and italic variable fonts with a `wght` axis each, you need to mark each font's position on the `ital` axis _in the Designspace lib `org.statmake.additionalLocations` key_. The Designspace `<axes>` elements are not supposed to hold this information, so it must be done in a separate lib key.
+
+1. Write a Stylespace file that describes each stop of all axes available in the entire family. See [tests/data/Test.stylespace](tests/data/Test.stylespace) for an annotated example. You can also use it as a starting point.
+2. You can have the file stand-alone or use the Designspace lib's `org.statmake.stylespacePath` key to store the path to the Stylespace file relative to the Designspace file. See [tests/data/TestExternalStylespace.designspace](tests/data/TestExternalStylespace.designspace) for an example.
+3. If you have one or more Designspace files which do not define all axes available to the family, you have to annotate them with the missing axis locations to get a complete `STAT` table. See the lib key at the bottom of [tests/data/Test_Wght_Upright.designspace](tests/data/Test_Wght_Upright.designspace) and [tests/data/Test_Wght_Italic.designspace](tests/data/Test_Wght_Italic.designspace) for an example.
+4. Generate the variable font(s) as normal
+5. If...
+    1. ... you store the Stylespace file stand-alone: run `statmake --designspace variable_font.designspace --stylespace your.stylespace variable_font.ttf`.
+    2. ... you store the Stylespace inline in the Designspace file or as a stand-alone file and added the relative path to it in the Designspace's `org.statmake.stylespacePath` key: run `statmake --designspace variable_font.designspace variable_font.ttf`
+
+Be sure to use the Designspace file that was used to generate the font to get the correct missing axis location definitions.
+
+### Designspace file with inline Stylespace data
+
+If you are producing a single variable font containing an entire family, this approach will save you an external file.
+
+1. Write the file as above, point 1.
+2. Insert it into the Designspace file's lib under the `org.statmake.stylespace` key. See [tests/data/TestInlineStylespace.designspace](tests/data/TestInlineStylespace.designspace) for an example.
+3. Proceed from point 3 above.
+
+## Q: Can I please have something other than a .plist file?
 
 Yes, but you have to convert it to `.plist` yourself, as statmake currently only read `.plist` files. One possible converter is Adam Twardoch's [yaplon](https://pypi.org/project/yaplon/).

--- a/statmake/lib.py
+++ b/statmake/lib.py
@@ -2,7 +2,6 @@ import collections
 import copy
 from typing import Dict, Mapping, Optional, Set
 
-import fontTools.misc.py23
 import fontTools.ttLib
 import fontTools.ttLib.tables.otTables as otTables
 
@@ -179,7 +178,7 @@ def _new_axis_record(tag: str, name_id: int, ordering: Optional[int]):
     if ordering is None:
         raise ValueError("ordering must be an integer.")
     axis_record = otTables.AxisRecord()
-    axis_record.AxisTag = fontTools.misc.py23.Tag(tag)
+    axis_record.AxisTag = tag
     axis_record.AxisNameID = name_id
     axis_record.AxisOrdering = ordering
     return axis_record

--- a/statmake/lib.py
+++ b/statmake/lib.py
@@ -89,7 +89,7 @@ def generate_name_and_STAT_variable(
         for k, v in instance.coordinates.items():
             if v not in stylespace_stops[k]:
                 raise ValueError(
-                    f"There is no Stylespace entry for stop {v} on axis {k}."
+                    f"There is no Stylespace entry for stop {v} on the '{k}' axis."
                 )
             axis_stops[k].add(v)
 
@@ -97,7 +97,7 @@ def generate_name_and_STAT_variable(
         axis_tag = name_to_tag[k]
         if v not in stylespace_stops[axis_tag]:
             raise ValueError(
-                f"There is no Stylespace entry for stop {v} on axis {k} (from "
+                f"There is no Stylespace entry for stop {v} on the '{k}' axis (from "
                 "additional locations)."
             )
         axis_stops[axis_tag].add(v)

--- a/tests/data/TestExternalStylespace.designspace
+++ b/tests/data/TestExternalStylespace.designspace
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<designspace format="4.0">
+  <axes>
+    <axis default="200" maximum="900" minimum="200" name="Weight" tag="wght">
+      <map input="200" output="0" />
+      <map input="300" output="100" />
+      <map input="333" output="333" />
+      <map input="400" output="368" />
+      <map input="600" output="600" />
+      <map input="650" output="789" />
+      <map input="700" output="824" />
+      <map input="900" output="1000" />
+    </axis>
+  </axes>
+
+  <sources>
+    <source filename="master1.ufo" stylename="Extra Light">
+      <location>
+        <dimension name="Weight" xvalue="0" />
+      </location>
+    </source>
+    <source filename="master2.ufo" stylename="Black">
+      <location>
+        <dimension name="Weight" xvalue="1000" />
+      </location>
+    </source>
+  </sources>
+
+  <instances>
+    <instance stylename="Extra Light">
+      <location>
+        <dimension name="Weight" xvalue="0" />
+      </location>
+    </instance>
+    <instance stylename="Light">
+      <location>
+        <dimension name="Weight" xvalue="100" />
+      </location>
+    </instance>
+    <instance stylename="Regular">
+      <location>
+        <dimension name="Weight" xvalue="368" />
+      </location>
+    </instance>
+    <instance stylename="Semi Bold">
+      <location>
+        <dimension name="Weight" xvalue="600" />
+      </location>
+    </instance>
+    <instance stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="824" />
+      </location>
+    </instance>
+    <instance stylename="Black">
+      <location>
+        <dimension name="Weight" xvalue="1000" />
+      </location>
+    </instance>
+  </instances>
+
+  <lib>
+    <dict>
+      <key>org.statmake.stylespacePath</key>
+      <string>Test.stylespace</string>
+      <key>org.statmake.additionalLocations</key>
+      <dict>
+        <key>Italic</key>
+        <integer>0</integer>
+      </dict>
+    </dict>
+  </lib>
+</designspace>

--- a/tests/data/TestInlineStylespace.designspace
+++ b/tests/data/TestInlineStylespace.designspace
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="utf-8"?>
+<designspace format="4.0">
+  <axes>
+    <axis default="200" maximum="900" minimum="200" name="Weight" tag="wght">
+      <map input="200" output="0" />
+      <map input="300" output="100" />
+      <map input="333" output="333" />
+      <map input="400" output="368" />
+      <map input="600" output="600" />
+      <map input="650" output="789" />
+      <map input="700" output="824" />
+      <map input="900" output="1000" />
+    </axis>
+  </axes>
+
+  <sources>
+    <source filename="master1.ufo" stylename="Extra Light">
+      <location>
+        <dimension name="Weight" xvalue="0" />
+      </location>
+    </source>
+    <source filename="master2.ufo" stylename="Black">
+      <location>
+        <dimension name="Weight" xvalue="1000" />
+      </location>
+    </source>
+  </sources>
+
+  <instances>
+    <instance stylename="Extra Light">
+      <location>
+        <dimension name="Weight" xvalue="0" />
+      </location>
+    </instance>
+    <instance stylename="Light">
+      <location>
+        <dimension name="Weight" xvalue="100" />
+      </location>
+    </instance>
+    <instance stylename="Regular">
+      <location>
+        <dimension name="Weight" xvalue="368" />
+      </location>
+    </instance>
+    <instance stylename="Semi Bold">
+      <location>
+        <dimension name="Weight" xvalue="600" />
+      </location>
+    </instance>
+    <instance stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="824" />
+      </location>
+    </instance>
+    <instance stylename="Black">
+      <location>
+        <dimension name="Weight" xvalue="1000" />
+      </location>
+    </instance>
+  </instances>
+
+  <lib>
+    <dict>
+      <key>org.statmake.stylespace</key>
+      <dict>
+        <key>axes</key>
+        <array>
+          <dict>
+            <key>name</key>
+            <string>Weight</string>
+            <key>tag</key>
+            <string>wght</string>
+            <key>locations</key>
+            <array>
+              <dict>
+                <key>name</key>
+                <string>XLight</string>
+                <key>value</key>
+                <integer>200</integer>
+              </dict>
+              <dict>
+                <key>name</key>
+                <string>Light</string>
+                <key>value</key>
+                <integer>300</integer>
+              </dict>
+              <dict>
+                <key>name</key>
+                <dict>
+                  <key>en</key>
+                  <string>Regular</string>
+                  <key>de</key>
+                  <string>Regulär</string>
+                </dict>
+                <key>value</key>
+                <integer>400</integer>
+                <key>linked_value</key>
+                <integer>700</integer>
+                <key>flags</key>
+                <array>
+                  <string>ElidableAxisValueName</string>
+                </array>
+              </dict>
+              <dict>
+                <key>name</key>
+                <string>Semi Bold</string>
+                <key>value</key>
+                <integer>600</integer>
+              </dict>
+              <dict>
+                <key>name</key>
+                <dict>
+                  <key>en</key>
+                  <string>Bold</string>
+                </dict>
+                <key>value</key>
+                <integer>700</integer>
+              </dict>
+              <dict>
+                <key>name</key>
+                <string>Black</string>
+                <key>value</key>
+                <integer>900</integer>
+                <key>range</key>
+                <array>
+                  <integer>701</integer>
+                  <integer>900</integer>
+                </array>
+              </dict>
+            </array>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>Italic</string>
+            <key>tag</key>
+            <string>ital</string>
+            <key>locations</key>
+            <array>
+              <dict>
+                <key>name</key>
+                <string>Upright</string>
+                <key>value</key>
+                <integer>0</integer>
+                <key>linked_value</key>
+                <integer>1</integer>
+                <key>flags</key>
+                <array>
+                  <string>ElidableAxisValueName</string>
+                </array>
+              </dict>
+              <dict>
+                <key>name</key>
+                <string>Italic</string>
+                <key>value</key>
+                <integer>1</integer>
+              </dict>
+            </array>
+          </dict>
+        </array>
+      </dict>
+      <key>org.statmake.additionalLocations</key>
+      <dict>
+        <key>Italic</key>
+        <integer>0</integer>
+      </dict>
+    </dict>
+  </lib>
+</designspace>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,23 @@ def test_cli_stylespace_in_designspace(datadir, tmp_path):
     assert v == TEST_WGHT_UPRIGHT_STAT_DUMP
 
 
+def test_cli_designspace_stylespace_external(datadir, tmp_path):
+    varfont = empty_varfont(datadir / "Test_Wght_Upright.designspace")
+    varfont.save(tmp_path / "varfont.ttf")
+
+    statmake.cli.main(
+        [
+            "-m",
+            str(datadir / "TestExternalStylespace.designspace"),
+            str(tmp_path / "varfont.ttf"),
+        ]
+    )
+
+    font = fontTools.ttLib.TTFont(tmp_path / "varfont.ttf")
+    v = testutil.dump_axis_values(font, font["STAT"].table.AxisValueArray.AxisValue)
+    assert v == TEST_WGHT_UPRIGHT_STAT_DUMP
+
+
 def test_cli_stylespace_external(datadir, tmp_path):
     varfont = empty_varfont(datadir / "Test_Wght_Upright.designspace")
     varfont.save(tmp_path / "varfont.ttf")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,105 @@
+import fontTools.designspaceLib
+import pytest
+import ufo2ft
+import fontTools.ttLib
+
+import statmake.cli
+
+from . import testutil
+
+
+def test_cli_stylespace_in_designspace(datadir, tmp_path):
+    varfont = empty_varfont(datadir / "Test_Wght_Upright.designspace")
+    varfont.save(tmp_path / "varfont.ttf")
+
+    statmake.cli.main(
+        [
+            "-m",
+            str(datadir / "TestInlineStylespace.designspace"),
+            str(tmp_path / "varfont.ttf"),
+        ]
+    )
+
+    font = fontTools.ttLib.TTFont(tmp_path / "varfont.ttf")
+    v = testutil.dump_axis_values(font, font["STAT"].table.AxisValueArray.AxisValue)
+    assert v == TEST_WGHT_UPRIGHT_STAT_DUMP
+
+
+def test_cli_stylespace_external(datadir, tmp_path):
+    varfont = empty_varfont(datadir / "Test_Wght_Upright.designspace")
+    varfont.save(tmp_path / "varfont.ttf")
+
+    statmake.cli.main(
+        [
+            "-m",
+            str(datadir / "Test_Wght_Upright.designspace"),
+            "--stylespace",
+            str(datadir / "Test.stylespace"),
+            str(tmp_path / "varfont.ttf"),
+        ]
+    )
+
+    font = fontTools.ttLib.TTFont(tmp_path / "varfont.ttf")
+    v = testutil.dump_axis_values(font, font["STAT"].table.AxisValueArray.AxisValue)
+    assert v == TEST_WGHT_UPRIGHT_STAT_DUMP
+
+
+def test_cli_stylespace_in_broken_designspace(datadir, tmp_path):
+    with pytest.raises(SystemExit):
+        statmake.cli.main(
+            [
+                "-m",
+                str(datadir / "Test_Wght_Upright.designspace"),
+                str(tmp_path / "varfont.ttf"),
+            ]
+        )
+
+
+def empty_varfont(designspace_path):
+    designspace = fontTools.designspaceLib.DesignSpaceDocument.fromfile(
+        designspace_path
+    )
+    for source in designspace.sources:
+        source.font = testutil.empty_UFO(source.styleName)
+    ufo2ft.compileInterpolatableTTFsFromDS(designspace, inplace=True)
+    varfont, _, _ = fontTools.varLib.build(designspace)
+    return varfont
+
+
+TEST_WGHT_UPRIGHT_STAT_DUMP = [
+    {"Format": 1, "Name": {"en": "XLight"}, "Flags": 0, "AxisIndex": 0, "Value": 200.0},
+    {"Format": 1, "Name": {"en": "Light"}, "Flags": 0, "AxisIndex": 0, "Value": 300.0},
+    {
+        "Format": 3,
+        "Name": {"de": "Regulär", "en": "Regular"},
+        "Flags": 2,
+        "AxisIndex": 0,
+        "Value": 400.0,
+        "LinkedValue": 700.0,
+    },
+    {
+        "Format": 1,
+        "Name": {"en": "Semi Bold"},
+        "Flags": 0,
+        "AxisIndex": 0,
+        "Value": 600.0,
+    },
+    {"Format": 1, "Name": {"en": "Bold"}, "Flags": 0, "AxisIndex": 0, "Value": 700.0},
+    {
+        "Format": 2,
+        "Name": {"en": "Black"},
+        "Flags": 0,
+        "AxisIndex": 0,
+        "NominalValue": 900.0,
+        "RangeMinValue": 701.0,
+        "RangeMaxValue": 900.0,
+    },
+    {
+        "Format": 3,
+        "Name": {"en": "Upright"},
+        "Flags": 2,
+        "AxisIndex": 1,
+        "Value": 0.0,
+        "LinkedValue": 1.0,
+    },
+]

--- a/tests/test_make_stat.py
+++ b/tests/test_make_stat.py
@@ -1,5 +1,7 @@
 import pytest
 
+import fontTools.designspaceLib
+
 import statmake.classes
 import statmake.lib
 
@@ -18,6 +20,21 @@ def test_load_stylespace_broken_ordering(datadir):
 
 def test_load_stylespace_no_format4(datadir):
     statmake.classes.Stylespace.from_file(datadir / "TestNoFormat4.stylespace")
+
+
+def test_load_from_designspace(datadir):
+    designspace = fontTools.designspaceLib.DesignSpaceDocument.fromfile(
+        datadir / "TestInlineStylespace.designspace"
+    )
+    statmake.classes.Stylespace.from_designspace(designspace)
+
+
+def test_load_from_broken_designspace(datadir):
+    designspace = fontTools.designspaceLib.DesignSpaceDocument.fromfile(
+        datadir / "TestNoFormat4.stylespace"
+    )
+    with pytest.raises(ValueError, match=r".* lib .*"):
+        statmake.classes.Stylespace.from_designspace(designspace)
 
 
 def test_generation_incomplete_stylespace(datadir):


### PR DESCRIPTION
Closes #8 

Todo:

- [x] Allow either org.statmake.stylespace (inline) or org.statmake.stylespacePath (file)