### PR TITLE
Pin cattrs dep for Python 3.8 compat

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1,29 +1,24 @@
 [[package]]
-category = "main"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-marker = "extra == \"ufo\""
-name = "appdirs"
-optional = false
-python-versions = "*"
-version = "1.4.3"
-
-[[package]]
 category = "dev"
 description = "An abstract syntax tree for Python with inference support."
 name = "astroid"
 optional = false
-python-versions = ">=3.4.*"
-version = "2.2.5"
+python-versions = ">=3.5.*"
+version = "2.3.3"
 
 [package.dependencies]
-lazy-object-proxy = "*"
-six = "*"
-typed-ast = ">=1.3.0"
-wrapt = "*"
+lazy-object-proxy = ">=1.4.0,<1.5.0"
+six = ">=1.12,<2.0"
+wrapt = ">=1.11.0,<1.12.0"
+
+[package.dependencies.typed-ast]
+python = "<3.8"
+version = ">=1.4.0,<1.5"
 
 [[package]]
 category = "dev"
 description = "Atomic file writes."
+marker = "python_version >= \"3.5\" and sys_platform == \"win32\" or sys_platform == \"win32\""
 name = "atomicwrites"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
@@ -35,19 +30,25 @@ description = "Classes Without Boilerplate"
 name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "19.1.0"
+version = "19.3.0"
+
+[package.extras]
+azure-pipelines = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "pytest-azurepipelines"]
+dev = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "pre-commit"]
+docs = ["sphinx", "zope.interface"]
+tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 
 [[package]]
 category = "dev"
 description = "Boolean operations on paths."
 name = "booleanoperations"
 optional = false
-python-versions = "*"
-version = "0.8.2"
+python-versions = ">=3.6"
+version = "0.9.0"
 
 [package.dependencies]
-fonttools = ">=3.32.0"
-pyclipper = ">=1.0.5"
+fonttools = ">=4.0.2"
+pyclipper = ">=1.1.0.post1"
 
 [[package]]
 category = "main"
@@ -55,38 +56,48 @@ description = "Composable complex class support for attrs."
 name = "cattrs"
 optional = false
 python-versions = "*"
-version = "0.9.0"
+version = "1.0.0rc0"
 
 [package.dependencies]
 attrs = ">=17.3"
 
+[package.extras]
+dev = ["bumpversion", "wheel", "watchdog", "flake8", "tox", "coverage", "sphinx", "pytest", "hypothesis", "pendulum"]
+
+[package.source]
+reference = "bb48897a7f389332d6111a239dcf3bf4a11b526f"
+type = "git"
+url = "https://github.com/Tinche/cattrs.git"
 [[package]]
 category = "dev"
 description = "Cross-platform colored terminal text."
 marker = "python_version >= \"3.5\" and sys_platform == \"win32\" or sys_platform == \"win32\""
 name = "colorama"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.4.1"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.4.3"
 
 [[package]]
 category = "dev"
 description = "A CFF subroutinizer for fontTools."
 name = "compreffor"
 optional = false
-python-versions = "*"
-version = "0.4.6.post1"
+python-versions = ">=3.6"
+version = "0.5.0"
 
 [package.dependencies]
-fonttools = ">=3.1"
+fonttools = ">=4"
 
 [[package]]
 category = "dev"
 description = "Code coverage measurement for Python"
 name = "coverage"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4"
-version = "4.5.4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "5.0"
+
+[package.extras]
+toml = ["toml"]
 
 [[package]]
 category = "dev"
@@ -94,21 +105,15 @@ description = "Cubic-to-quadratic bezier curve conversion"
 name = "cu2qu"
 optional = false
 python-versions = "*"
-version = "1.6.5"
+version = "1.6.6"
 
 [package.dependencies]
-fonttools = ">=3.32.0"
+[package.dependencies.fonttools]
+extras = ["ufo"]
+version = ">=3.32.0"
 
-[[package]]
-category = "dev"
-description = "A set of flexible objects for representing UFO data."
-name = "defcon"
-optional = false
-python-versions = "*"
-version = "0.6.0"
-
-[package.dependencies]
-fonttools = ">=3.31.0"
+[package.extras]
+cli = ["defcon (>=0.6.0)"]
 
 [[package]]
 category = "main"
@@ -116,36 +121,35 @@ description = "Tools to manipulate font files"
 name = "fonttools"
 optional = false
 python-versions = ">=3.6"
-version = "4.0.0"
+version = "4.2.2"
 
-[package.dependencies]
-fs = ">=2.2.0,<3"
-
-[[package]]
-category = "main"
-description = "Python's filesystem abstraction layer"
-marker = "extra == \"ufo\""
-name = "fs"
-optional = false
-python-versions = "*"
-version = "2.4.10"
-
-[package.dependencies]
-appdirs = ">=1.4.0,<1.5.0"
-pytz = "*"
-setuptools = "*"
-six = ">=1.10,<2.0"
+[package.extras]
+all = ["fs (>=2.2.0,<3)", "lxml (>=4.0,<5)", "zopfli (>=0.1.4)", "lz4 (>=1.7.4.2)", "matplotlib", "sympy", "brotli (>=1.0.1)", "scipy", "brotlipy (>=0.7.0)", "munkres", "unicodedata2 (>=12.1.0)", "xattr"]
+graphite = ["lz4 (>=1.7.4.2)"]
+interpolatable = ["scipy", "munkres"]
+lxml = ["lxml (>=4.0,<5)"]
+plot = ["matplotlib"]
+symfont = ["sympy"]
+type1 = ["xattr"]
+ufo = ["fs (>=2.2.0,<3)"]
+unicode = ["unicodedata2 (>=12.1.0)"]
+woff = ["zopfli (>=0.1.4)", "brotli (>=1.0.1)", "brotlipy (>=0.7.0)"]
 
 [[package]]
 category = "dev"
 description = "Read metadata from Python packages"
+marker = "python_version >= \"3.5\" and python_version < \"3.8\" or python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
-python-versions = ">=2.7,!=3.0,!=3.1,!=3.2,!=3.3"
-version = "0.19"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "1.3.0"
 
 [package.dependencies]
 zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "rst.linker"]
+testing = ["packaging", "importlib-resources"]
 
 [[package]]
 category = "dev"
@@ -155,13 +159,19 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "4.3.21"
 
+[package.extras]
+pipfile = ["pipreqs", "requirementslib"]
+pyproject = ["toml"]
+requirements = ["pipreqs", "pip-api"]
+xdg_home = ["appdirs (>=1.4.0)"]
+
 [[package]]
 category = "dev"
 description = "A fast and thorough lazy object proxy."
 name = "lazy-object-proxy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.4.2"
+version = "1.4.3"
 
 [[package]]
 category = "dev"
@@ -176,31 +186,34 @@ category = "dev"
 description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
-python-versions = ">=3.4"
-version = "7.2.0"
+python-versions = ">=3.5"
+version = "8.0.2"
 
 [[package]]
 category = "dev"
 description = "Optional static typing for Python"
-marker = "python_version >= \"3.5\""
+marker = "python_version >= \"3.5\" and python_version < \"3.8\" or python_version >= \"3.8\""
 name = "mypy"
 optional = false
-python-versions = "*"
-version = "0.720"
+python-versions = ">=3.5"
+version = "0.750"
 
 [package.dependencies]
 mypy-extensions = ">=0.4.0,<0.5.0"
 typed-ast = ">=1.4.0,<1.5.0"
 typing-extensions = ">=3.7.4"
 
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+
 [[package]]
 category = "dev"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
-marker = "python_version >= \"3.5\""
+marker = "python_version >= \"3.5\" and python_version < \"3.8\" or python_version >= \"3.8\""
 name = "mypy-extensions"
 optional = false
 python-versions = "*"
-version = "0.4.1"
+version = "0.4.3"
 
 [[package]]
 category = "dev"
@@ -208,10 +221,9 @@ description = "Core utilities for Python packages"
 name = "packaging"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "19.1"
+version = "19.2"
 
 [package.dependencies]
-attrs = "*"
 pyparsing = ">=2.0.2"
 six = "*"
 
@@ -221,10 +233,15 @@ description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.12.0"
+version = "0.13.1"
 
 [package.dependencies]
-importlib-metadata = ">=0.12"
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = ">=0.12"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
 
 [[package]]
 category = "dev"
@@ -240,18 +257,18 @@ description = "Cython wrapper for the C++ translation of the Angus Johnson's Cli
 name = "pyclipper"
 optional = false
 python-versions = "*"
-version = "1.1.0.post1"
+version = "1.1.0.post3"
 
 [[package]]
 category = "dev"
 description = "python code static checker"
 name = "pylint"
 optional = false
-python-versions = ">=3.4.*"
-version = "2.3.1"
+python-versions = ">=3.5.*"
+version = "2.4.4"
 
 [package.dependencies]
-astroid = ">=2.2.0,<3"
+astroid = ">=2.3.0,<2.4"
 colorama = "*"
 isort = ">=4.2.5,<5"
 mccabe = ">=0.6,<0.7"
@@ -262,7 +279,7 @@ description = "Python parsing module"
 name = "pyparsing"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.2"
+version = "2.4.5"
 
 [[package]]
 category = "dev"
@@ -270,7 +287,7 @@ description = "pytest: simple powerful testing with Python"
 name = "pytest"
 optional = false
 python-versions = ">=3.5"
-version = "5.1.1"
+version = "5.3.2"
 
 [package.dependencies]
 atomicwrites = ">=1.0"
@@ -286,17 +303,23 @@ wcwidth = "*"
 python = "<3.8"
 version = ">=0.12"
 
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
 [[package]]
 category = "dev"
 description = "Pytest plugin for measuring coverage."
 name = "pytest-cov"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.7.1"
+version = "2.8.1"
 
 [package.dependencies]
 coverage = ">=4.4"
 pytest = ">=3.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "virtualenv"]
 
 [[package]]
 category = "dev"
@@ -304,38 +327,33 @@ description = "Mypy static type checker plugin for Pytest"
 name = "pytest-mypy"
 optional = false
 python-versions = "~=3.4"
-version = "0.3.3"
+version = "0.4.2"
 
 [package.dependencies]
-[package.dependencies.mypy]
-python = ">=3.5"
-version = ">=0.570"
+[[package.dependencies.mypy]]
+python = ">=3.5,<3.8"
+version = ">=0.500"
+
+[[package.dependencies.mypy]]
+python = ">=3.8"
+version = ">=0.700"
 
 [package.dependencies.pytest]
 python = ">=3.5"
 version = ">=2.8"
 
 [[package]]
-category = "main"
-description = "World timezone definitions, modern and historical"
-marker = "extra == \"ufo\""
-name = "pytz"
-optional = false
-python-versions = "*"
-version = "2019.2"
-
-[[package]]
-category = "main"
+category = "dev"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
-version = "1.12.0"
+version = "1.13.0"
 
 [[package]]
 category = "dev"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
-marker = "implementation_name == \"cpython\" or python_version >= \"3.5\""
+marker = "implementation_name == \"cpython\" and python_version < \"3.8\" or python_version >= \"3.5\" and python_version < \"3.8\" or python_version >= \"3.8\""
 name = "typed-ast"
 optional = false
 python-versions = "*"
@@ -343,51 +361,50 @@ version = "1.4.0"
 
 [[package]]
 category = "dev"
-description = "Type Hints for Python"
-marker = "python_version >= \"3.5\""
-name = "typing"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+marker = "python_version >= \"3.5\" and python_version < \"3.8\" or python_version >= \"3.8\""
+name = "typing-extensions"
 optional = false
 python-versions = "*"
 version = "3.7.4.1"
 
 [[package]]
 category = "dev"
-description = "Backported and Experimental Type Hints for Python 3.5+"
-marker = "python_version >= \"3.5\""
-name = "typing-extensions"
-optional = false
-python-versions = "*"
-version = "3.7.4"
-
-[package.dependencies]
-typing = ">=3.7.4"
-
-[[package]]
-category = "dev"
 description = "A bridge between UFOs and FontTools."
 name = "ufo2ft"
 optional = false
-python-versions = "*"
-version = "2.9.1"
+python-versions = ">=3.6"
+version = "2.11.1"
 
 [package.dependencies]
-booleanOperations = ">=0.8.2"
+booleanOperations = ">=0.9.0"
 compreffor = ">=0.4.6"
-cu2qu = ">=1.6.5"
-defcon = ">=0.6.0"
-fonttools = ">=3.43.0"
+cu2qu = ">=1.6.6"
+
+[package.dependencies.fonttools]
+extras = ["ufo"]
+version = ">=4.2.0"
+
+[package.extras]
+pathops = ["skia-pathops (>=0.2.0)"]
 
 [[package]]
 category = "dev"
-description = "ufoLib2 is a UFO font library."
+description = "ufoLib2 is a UFO font processing library."
 name = "ufolib2"
 optional = false
 python-versions = ">=3.6"
-version = "0.4.0"
+version = "0.5.1"
 
 [package.dependencies]
 attrs = ">=18.2.0"
-fonttools = ">=3.34.0"
+
+[package.dependencies.fonttools]
+extras = ["ufo"]
+version = ">=3.34.0"
+
+[package.extras]
+lxml = ["lxml"]
 
 [[package]]
 category = "dev"
@@ -408,52 +425,290 @@ version = "1.11.2"
 [[package]]
 category = "dev"
 description = "Backport of pathlib-compatible object wrapper for zip files"
+marker = "python_version >= \"3.5\" and python_version < \"3.8\" or python_version < \"3.8\""
 name = "zipp"
 optional = false
 python-versions = ">=2.7"
-version = "0.5.2"
+version = "0.6.0"
+
+[package.dependencies]
+more-itertools = "*"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["pathlib2", "contextlib2", "unittest2"]
 
 [metadata]
-content-hash = "cf1e9c236591289c34d974f8f9583e5388f66d7d7ff47a606fab5b8935106bd5"
+content-hash = "2db4300c7d2e6d2dee2ff6b8057d196e0d8f00bf9e64cdaa7bcb275369639d19"
 python-versions = "^3.6"
 
-[metadata.hashes]
-appdirs = ["9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92", "d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"]
-astroid = ["6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4", "b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"]
-atomicwrites = ["03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4", "75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"]
-attrs = ["69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79", "f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"]
-booleanoperations = ["1750def605e53ca13cf45fedd31b360d241cc6082523e4b71d86c72dd3e9bc8a", "5163839dfe337ff7e30e80feee47a82a9720c972b5ae7779118aa995c30d731b"]
-cattrs = ["2232a568e079f30601de63839f4101283cb594c8719f5311bede25f89d0e09b7", "f1215991553dfa7623ce15861663153348e675c1f316095affef473c804116ba"]
-colorama = ["05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d", "f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"]
-compreffor = ["115e4482a7c6cc38875d912f6174a33325c0dd897b3a16fec9b691c6ab930dd7", "1514e847ccb7ddedfd737a5b4d9288d2373c487ba442df831b53da20b63eca8c", "1d920117959f0b1ffd139a750f7871290094047d12aa8d2511522c9054e54a2d", "1ef625b544f334ed9e499a7ded0a0f9dfc540ed4c2d97648281d0438981fbd26", "2f7f0252022819add4d9d4ff61de0cb3aa798c029715cdf165cea2f4389d9eee", "341a5f4e98651ad78833df37cc6ac7551a6c402708642928faf36812ed362c77", "3a0d9d58aa52388231b06c82c6179742b5489e7505c22814c727de2515cb13ec", "5263d09b9d77a3778a5e912dcf1ec83a380ba1fe2b9677891f02f6fd82859a01", "682c5bbd3ce0dc0113d04ef82479a1c8e70c4b59c17be30ba7075f7435696362", "6e3027d0247f3c52dbda7bce1143c9e2c7aa4a496c8e0d76d7dc424bfc9a6749", "6e53a103b89c3f33e173cc1485652b96a7064438bce7efae571ff5c29312eefb", "7056beebec3a64b47300bbcddbf93f3fa6e0d5258767c4b6ea2fdd0cee13ec87", "70cec399f09f506ac25c3b9d5c5f05a12c2f921aeab12dbe273df2f9b0441f7b", "71e053c6c2227016d6c87bc246d97ad30a91f5f2f63e09a1a0fbab18af425cde", "778f7ca8e8584dc20153e9823d4384a5651d33b416d38e25e2288e8be1a243d2", "7a94115e4ff16657f9e869a4131f5567cc28732a0b8fae3e18eb669d4b17f9ec", "9cc069bef16cd95ca8e500dfd75a5308cb63265ad38e407e45a0dad86a3756e6", "9d50df4cae35e1308163654b9b693abb859252d3affd181abb435c579f3fbb5d", "b521d33dedd3dc92fe434de96e5e73beed646c752cbf977d9f6cb2030d89b408", "c3e2bb069aba38a0f519f6359530d2ddddcc39f0367abc805b7464360567c695", "c7635ea46ea2c3811535d1a41f41d41064d0155261c356709aadf4c2ed0e734e", "d82f43c5fa02884ea79a348a43b8f2d7d3a1f5c50b04f9fd739dff10c8d6a99b", "e845e763c273a05ecfab5d30e479a9b1ce268c5e3c123a884927ca2ad85b284c"]
-coverage = ["08907593569fe59baca0bf152c43f3863201efb6113ecb38ce7e97ce339805a6", "0be0f1ed45fc0c185cfd4ecc19a1d6532d72f86a2bac9de7e24541febad72650", "141f08ed3c4b1847015e2cd62ec06d35e67a3ac185c26f7635f4406b90afa9c5", "19e4df788a0581238e9390c85a7a09af39c7b539b29f25c89209e6c3e371270d", "23cc09ed395b03424d1ae30dcc292615c1372bfba7141eb85e11e50efaa6b351", "245388cda02af78276b479f299bbf3783ef0a6a6273037d7c60dc73b8d8d7755", "331cb5115673a20fb131dadd22f5bcaf7677ef758741312bee4937d71a14b2ef", "386e2e4090f0bc5df274e720105c342263423e77ee8826002dcffe0c9533dbca", "3a794ce50daee01c74a494919d5ebdc23d58873747fa0e288318728533a3e1ca", "60851187677b24c6085248f0a0b9b98d49cba7ecc7ec60ba6b9d2e5574ac1ee9", "63a9a5fc43b58735f65ed63d2cf43508f462dc49857da70b8980ad78d41d52fc", "6b62544bb68106e3f00b21c8930e83e584fdca005d4fffd29bb39fb3ffa03cb5", "6ba744056423ef8d450cf627289166da65903885272055fb4b5e113137cfa14f", "7494b0b0274c5072bddbfd5b4a6c6f18fbbe1ab1d22a41e99cd2d00c8f96ecfe", "826f32b9547c8091679ff292a82aca9c7b9650f9fda3e2ca6bf2ac905b7ce888", "93715dffbcd0678057f947f496484e906bf9509f5c1c38fc9ba3922893cda5f5", "9a334d6c83dfeadae576b4d633a71620d40d1c379129d587faa42ee3e2a85cce", "af7ed8a8aa6957aac47b4268631fa1df984643f07ef00acd374e456364b373f5", "bf0a7aed7f5521c7ca67febd57db473af4762b9622254291fbcbb8cd0ba5e33e", "bf1ef9eb901113a9805287e090452c05547578eaab1b62e4ad456fcc049a9b7e", "c0afd27bc0e307a1ffc04ca5ec010a290e49e3afbe841c5cafc5c5a80ecd81c9", "dd579709a87092c6dbee09d1b7cfa81831040705ffa12a1b248935274aee0437", "df6712284b2e44a065097846488f66840445eb987eb81b3cc6e4149e7b6982e1", "e07d9f1a23e9e93ab5c62902833bf3e4b1f65502927379148b6622686223125c", "e2ede7c1d45e65e209d6093b762e98e8318ddeff95317d07a27a2140b80cfd24", "e4ef9c164eb55123c62411f5936b5c2e521b12356037b6e1c2617cef45523d47", "eca2b7343524e7ba246cab8ff00cab47a2d6d54ada3b02772e908a45675722e2", "eee64c616adeff7db37cc37da4180a3a5b6177f5c46b187894e633f088fb5b28", "ef824cad1f980d27f26166f86856efe11eff9912c4fed97d3804820d43fa550c", "efc89291bd5a08855829a3c522df16d856455297cf35ae827a37edac45f466a7", "fa964bae817babece5aa2e8c1af841bebb6d0b9add8e637548809d040443fee0", "ff37757e068ae606659c28c3bd0d923f9d29a85de79bf25b2b34b148473b5025"]
-cu2qu = ["01a70624163b1a73792ef0f585b614e71e5c4885d06f545aebae85202f71ba62", "0ff0161a4dbc4d84d1d38a17647332d304fbbb0f4536677ce83257d5921ad3fd", "1ee2503516892af930b96fdc1176151314387a015b6af897bd6fa456084260cc", "309d40e11702034f3c6770db20be11712a26d2e2911e436ac1ecb1769f3024d6", "321b62d398c6c39507acc223315b845a54c255ae7c4190289e2584a655b5e160", "4b3bc12761c6ac5cfa3cc95babde8cbec5cd0041bc311a33f403efd7765d8cad", "57ed7856ee520df2cf10e288dbaeba2f9e54da918c12f2ac83d164055067295a", "6bf3dbd5daa5c3ec5e1d6efb1eed36ed2563304398d2100424b673de9f64fd79", "77fa964432afbc7501d60246b87a82de2cf99711eabb60121ce14dcf99f300f9", "7a2f024e3a01fdba1a85290a0d7141abd8a375af80fb178d2412c1cf1e3f86df", "92e8db2338bde72df830556afb5d33cbd3c052c197b3262856646ff2308a2d0e", "b3b4a0d80798489906ca503c4a7a749e0a360670aa2f10f21dd01682e37b8293", "c9197aa2471112c2a7c87c8b509d81ca0daaadbe77a73ba6e0e9a72be3f58f20", "d6727edac77b2d8d3e56b04fe3237c089c2b151db03d6ee777cbb163c52c1c0a", "f10cd6088b7ee83b1a8f7eca886f4355e2152b47432a8e4e7b05eb6390cc7db4", "f3050119434c15cf47896fc50fd9ff2f46f18db3ada31fd8a9c996f456879c24", "f68bfc3c75dfa77dce9813671c86fe1bda2ed0e732dd5818566193097f038e74", "ffc205cc5895c8a39563c63dd9b215345014aff2877155e9a33ee48408dbc352"]
-defcon = ["52e461961b4b68ae6883f8a14a0d82f2d09f2de7a526b95c7d1b195c10ca745f", "e057303d188f1a0961a0c70eebdedceac7fe11e6cd30421324bb7ee33cfcd614"]
-fonttools = ["9415fda795f4ff8e89d41ab907388ec5a4c236f4774ea65a746d8c1e4e839d3d", "c095fc06da714c8364d5f44278afa05f4c70c8db7f36d1664aceb15d7be08d31"]
-fs = ["1b0113932a3428ddb6ecb86e8459080fe20044d12392617f13b91ae63ab0a273", "cd5a151beba0d027e4cd7f468e292f61587d1b6aa15215067f67bb0c188d4bfc"]
-importlib-metadata = ["23d3d873e008a513952355379d93cbcab874c58f4f034ff657c7a87422fa64e8", "80d2de76188eabfbfcf27e6a37342c2827801e59c4cc14b0371c56fed43820e3"]
-isort = ["54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1", "6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"]
-lazy-object-proxy = ["02b260c8deb80db09325b99edf62ae344ce9bc64d68b7a634410b8e9a568edbf", "18f9c401083a4ba6e162355873f906315332ea7035803d0fd8166051e3d402e3", "1f2c6209a8917c525c1e2b55a716135ca4658a3042b5122d4e3413a4030c26ce", "2f06d97f0ca0f414f6b707c974aaf8829c2292c1c497642f63824119d770226f", "616c94f8176808f4018b39f9638080ed86f96b55370b5a9463b2ee5c926f6c5f", "63b91e30ef47ef68a30f0c3c278fbfe9822319c15f34b7538a829515b84ca2a0", "77b454f03860b844f758c5d5c6e5f18d27de899a3db367f4af06bec2e6013a8e", "83fe27ba321e4cfac466178606147d3c0aa18e8087507caec78ed5a966a64905", "84742532d39f72df959d237912344d8a1764c2d03fe58beba96a87bfa11a76d8", "874ebf3caaf55a020aeb08acead813baf5a305927a71ce88c9377970fe7ad3c2", "9f5caf2c7436d44f3cec97c2fa7791f8a675170badbfa86e1992ca1b84c37009", "a0c8758d01fcdfe7ae8e4b4017b13552efa7f1197dd7358dc9da0576f9d0328a", "a4def978d9d28cda2d960c279318d46b327632686d82b4917516c36d4c274512", "ad4f4be843dace866af5fc142509e9b9817ca0c59342fdb176ab6ad552c927f5", "ae33dd198f772f714420c5ab698ff05ff900150486c648d29951e9c70694338e", "b4a2b782b8a8c5522ad35c93e04d60e2ba7f7dcb9271ec8e8c3e08239be6c7b4", "c462eb33f6abca3b34cdedbe84d761f31a60b814e173b98ede3c81bb48967c4f", "fd135b8d35dfdcdb984828c84d695937e58cc5f49e1c854eb311c4d6aa03f4f1"]
-mccabe = ["ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42", "dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"]
-more-itertools = ["409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832", "92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"]
-mypy = ["0107bff4f46a289f0e4081d59b77cef1c48ea43da5a0dbf0005d54748b26df2a", "07957f5471b3bb768c61f08690c96d8a09be0912185a27a68700f3ede99184e4", "10af62f87b6921eac50271e667cc234162a194e742d8e02fc4ddc121e129a5b0", "11fd60d2f69f0cefbe53ce551acf5b1cec1a89e7ce2d47b4e95a84eefb2899ae", "15e43d3b1546813669bd1a6ec7e6a11d2888db938e0607f7b5eef6b976671339", "352c24ba054a89bb9a35dd064ee95ab9b12903b56c72a8d3863d882e2632dc76", "437020a39417e85e22ea8edcb709612903a9924209e10b3ec6d8c9f05b79f498", "49925f9da7cee47eebf3420d7c0e00ec662ec6abb2780eb0a16260a7ba25f9c4", "6724fcd5777aa6cebfa7e644c526888c9d639bd22edd26b2a8038c674a7c34bd", "7a17613f7ea374ab64f39f03257f22b5755335b73251d0d253687a69029701ba", "cdc1151ced496ca1496272da7fc356580e95f2682be1d32377c22ddebdf73c91"]
-mypy-extensions = ["37e0e956f41369209a3d5f34580150bcacfabaa57b33a15c0b25f4b5725e0812", "b16cabe759f55e3409a7d231ebd2841378fb0c27a5d1994719e340e4f429ac3e"]
-packaging = ["a7ac867b97fdc07ee80a8058fe4435ccd274ecc3b0ed61d852d7d53055528cf9", "c491ca87294da7cc01902edbe30a5bc6c4c28172b5138ab4e4aa1b9d7bfaeafe"]
-pluggy = ["0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc", "b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"]
-py = ["64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa", "dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"]
-pyclipper = ["0b37d39bd9d4f330918de20c169e7d74108217a752533ec6ac54c6a8825adcec", "0d99acc5618faf8772164a3a067c1d1abd4513cf66b7b7a8d7adaa150a18376d", "4c4e9a643f6866f1ea4361b83a6a5c6a0d64e6a391a286e79b7f0844c2ae3c2a", "567947b8e31de852be32941872a72e843e679af8cf0826108be0a4c6108792a3", "623ab16641e4e408359420d615c6a395cb3da23a559a20e57402bebb216bd125", "6aa4bce5111e0bd2c50d452d940ddd87ef6c2632b2da6952fe2dec4f5e103173", "747bfd3e219d5f2c45e50d874ea6da4ae746b3a4601f28566fd29a6ab0966a7a", "78ebe32ccb6807bc8eac652ec9a7875dfa229e947b686a107acaf69259da3d8d", "7ecf2cc782ab3e3d33120aa3fc9da1bfd72155c6ad2ee358d14b81865dda2d65", "888e04d29717e9c47336c814094bd9523b3ec9ed371ce91dfa60636aae1de6f6", "8a8b6018d53fcce291f78dedca19994f82695eed3a2c9eff275691d4ed9aab51", "8bb79a30fd6078e589b39c164acd969d3f5f942a566b7e951c941f6d5c7106fe", "8f8ff492926c2d865bc58121bc15438e8698d8a9b7751b67892ef3516838d462", "abfb4c65937494bb5a3bb5fb3cf44cdb33ac88805effcd702afdb0d7bfb1803f", "acfbfe2a3e236a474100393661291681419ec89e74fb6a51db5325ddd280ab9a", "b03d1dcac192412a1f7125500dcd09baa0ccf9c27f1300870e80981907197583", "ba98f5472d6066386367a3e8d44c327b5438e746a7faf356e6b116338fe6492e", "bb89da8a321a9662330f18c1f8a88dd44966160e7a9e25c86ca16fbc1be31c0d", "bed37f2d2517e18976aa24477cce319fd48efa8fbafe9407101c599ba4a2b481", "c0fb993da9ef2ce62a9f62dcb14fff16f90bae57c073d8d4187072490eb41a68", "c964d5808aa5e44aae9500e70d3f08d5191edf6a355e183d8c6fb8f43dde77ad", "d6a2186a8a85121ee2732bd28c2243dd0451d8095d5e8426351b845fa409b974", "db6d0580bac8a642a31b0e07f220d3c94fe2dda39f559abc2d12713bff7dd3d0", "de693b6da86fbb69bf224bc89abfe479df205e827e20b4a431b03e37b2b5ee34", "e17d8d1adc834112ee8b092661da6231f7cfba9700297069c6b5bce71c07b9b4", "f064528ffb7486b1b2b21f833c729a63e5331e2e6073dfbc73b1d5e96a4d00a2", "f5e003f9ec3ced16691b7b0dbee39318aba3787ba85d01ef1f6627592c3ff75d", "fae29ba16ec075794c50242005be07fc3d5615b0cf3a86e2b60c1123446b574c"]
-pylint = ["5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09", "723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1"]
-pyparsing = ["6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80", "d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"]
-pytest = ["95b1f6db806e5b1b5b443efeb58984c24945508f93a866c1719e1a507a957d7c", "c3d5020755f70c82eceda3feaf556af9a341334414a8eca521a18f463bcead88"]
-pytest-cov = ["2b097cde81a302e1047331b48cadacf23577e431b61e9c6f49a1170bbe3d3da6", "e00ea4fdde970725482f1f35630d12f074e121a23801aabf2ae154ec6bdd343a"]
-pytest-mypy = ["419d1d4877d41a6a80f0eb31faa7c50bb9445557f7ff1b02a1a26d10d7dc7691", "917438af835beb87f14c9f6261137f8e992b3bf87ebf73f836ac7ede03424a0f"]
-pytz = ["26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32", "c894d57500a4cd2d5c71114aaab77dbab5eabd9022308ce5ac9bb93a60a6f0c7"]
-six = ["3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c", "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"]
-typed-ast = ["18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e", "262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e", "2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0", "354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c", "4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631", "630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4", "66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34", "71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b", "95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a", "bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233", "cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1", "d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36", "d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d", "d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a", "ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"]
-typing = ["91dfe6f3f706ee8cc32d38edbbf304e9b7583fb37108fef38229617f8b3eba23", "c8cabb5ab8945cd2f54917be357d134db9cc1eb039e59d1606dc1e60cb1d9d36", "f38d83c5a7a7086543a0f649564d661859c5146a85775ab90c0d2f93ffaa9714"]
-typing-extensions = ["2ed632b30bb54fc3941c382decfd0ee4148f5c591651c9272473fea2c6397d95", "b1edbbf0652660e32ae780ac9433f4231e7339c7f9a8057d0f042fcbcea49b87", "d8179012ec2c620d3791ca6fe2bf7979d979acdbef1fca0bc56b37411db682ed"]
-ufo2ft = ["224a37cc3a88f9c4a5194524e5d5814ddbf64da6134f251762082ed7e34bd92a", "e55ae7164d6da6d21d9c2efc8d95031edd752edd2b0c7df8cf215fd650feb216"]
-ufolib2 = ["953636dca68b5653e67ca58546e091b263bd0a5b32421a0a2ebb7af7a54165af", "a9687aa713242ff3251fdb0dfa910605759958fab11822bedfc7a37977f6585c"]
-wcwidth = ["3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e", "f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"]
-wrapt = ["565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"]
-zipp = ["4970c3758f4e89a7857a973b1e2a5d75bcdc47794442f2e2dd4fe8e0466e809a", "8a5712cfd3bb4248015eb3b0b3c54a5f6ee3f2425963ef2a0125b8bc40aafaec"]
+[metadata.files]
+astroid = [
+    {file = "astroid-2.3.3-py3-none-any.whl", hash = "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"},
+    {file = "astroid-2.3.3.tar.gz", hash = "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a"},
+]
+atomicwrites = [
+    {file = "atomicwrites-1.3.0-py2.py3-none-any.whl", hash = "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4"},
+    {file = "atomicwrites-1.3.0.tar.gz", hash = "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"},
+]
+attrs = [
+    {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
+    {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
+]
+booleanoperations = [
+    {file = "booleanOperations-0.9.0-py3-none-any.whl", hash = "sha256:86c291c2fba9faedff6f007c932d7f242dd9b4304e9c6ca8149f864d07877a59"},
+    {file = "booleanOperations-0.9.0.zip", hash = "sha256:8cfa821c32ad374fa120d6b2e0b444ebeac57c91e6631528645fa19ac2a281b8"},
+]
+cattrs = []
+colorama = [
+    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
+    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+]
+compreffor = [
+    {file = "compreffor-0.5.0-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:d0ed1c17b13599c387fad824ef2b74e9a367fdffe008c1b7aa65ffb1ac877cee"},
+    {file = "compreffor-0.5.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1c51eecdb7d225f9b103005e0c249811ac36a417c6f18584ccb393047efdd203"},
+    {file = "compreffor-0.5.0-cp36-cp36m-win32.whl", hash = "sha256:889e7cdb615b4f9c6dbb6559637d7fccb69fef0980329ead6ac4980d26844180"},
+    {file = "compreffor-0.5.0-cp36-cp36m-win_amd64.whl", hash = "sha256:c1291ba24c1a7bbcd8ac8323c90795423320cef8f5353f8e37e31336e8011d89"},
+    {file = "compreffor-0.5.0-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:7645d99977987f6860a6b096586f1248d5258eba9e5c98ff56ea475abdf49b6e"},
+    {file = "compreffor-0.5.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:81e9aef6850f565552c33eab3c6f1f6d71362a2e2e300635d7100b24f31f71d0"},
+    {file = "compreffor-0.5.0-cp37-cp37m-win32.whl", hash = "sha256:9ee89643131269c1b2356504245ffe7242df1cca2822271e83845afe56b45439"},
+    {file = "compreffor-0.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:0813de14f3cc083d5eac2d1d127fedb1bb804c106d384360781df9622e1c0019"},
+    {file = "compreffor-0.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:df367eb37dac0478b7ee2206142995ab5f678bcac9013d46b80933fa62c58efb"},
+    {file = "compreffor-0.5.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:92417091887a582ae27e53828c84e366fffbfe43f573d0962d0f1e8af0984be8"},
+    {file = "compreffor-0.5.0-cp38-cp38-win32.whl", hash = "sha256:ed6873d08ff398db2547a34ea74cee7d8f59fb05fc0a1440c367cef4bfe55283"},
+    {file = "compreffor-0.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:883faab722a90458e7fb81ccf1f0f34aa045b53c4e2363134ba1ba8c76f61066"},
+    {file = "compreffor-0.5.0.zip", hash = "sha256:b804999e0c256094e28a9cbb9306f6031b7cf6884bbb98fd44ad70eed6c4c2fd"},
+]
+coverage = [
+    {file = "coverage-5.0-cp27-cp27m-macosx_10_12_x86_64.whl", hash = "sha256:9c871b006c878a890c6e44a5b2f3c6291335324b298c904dc0402ee92ee1f0be"},
+    {file = "coverage-5.0-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:e5a675f6829c53c87d79117a8eb656cc4a5f8918185a32fc93ba09778e90f6db"},
+    {file = "coverage-5.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:81326f1095c53111f8afc95da281e1414185f4a538609a77ca50bdfa39a6c207"},
+    {file = "coverage-5.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:8873dc0d8f42142ea9f20c27bbdc485190fff93823c6795be661703369e5877d"},
+    {file = "coverage-5.0-cp27-cp27m-win32.whl", hash = "sha256:44b783b02db03c4777d8cf71bae19eadc171a6f2a96777d916b2c30a1eb3d070"},
+    {file = "coverage-5.0-cp27-cp27m-win_amd64.whl", hash = "sha256:d52c1c2d7e856cecc05aa0526453cb14574f821b7f413cc279b9514750d795c1"},
+    {file = "coverage-5.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:ba259f68250f16d2444cbbfaddaa0bb20e1560a4fdaad50bece25c199e6af864"},
+    {file = "coverage-5.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:475bf7c4252af0a56e1abba9606f1e54127cdf122063095c75ab04f6f99cf45e"},
+    {file = "coverage-5.0-cp35-cp35m-macosx_10_12_x86_64.whl", hash = "sha256:91f2491aeab9599956c45a77c5666d323efdec790bfe23fcceafcd91105d585a"},
+    {file = "coverage-5.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:979daa8655ae5a51e8e7a24e7d34e250ae8309fd9719490df92cbb2fe2b0422b"},
+    {file = "coverage-5.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:1a4b6b6a2a3a6612e6361130c2cc3dc4378d8c221752b96167ccbad94b47f3cd"},
+    {file = "coverage-5.0-cp35-cp35m-win32.whl", hash = "sha256:56b13000acf891f700f5067512b804d1ec8c301d627486c678b903859d07f798"},
+    {file = "coverage-5.0-cp35-cp35m-win_amd64.whl", hash = "sha256:81042a24f67b96e4287774014fa27220d8a4d91af1043389e4d73892efc89ac6"},
+    {file = "coverage-5.0-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:fec32646b98baf4a22fdceb08703965bd16dea09051fbeb31a04b5b6e72b846c"},
+    {file = "coverage-5.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:7fe3e2fde2bf1d7ce25ebcd2d3de3650b8d60d9a73ce6dcef36e20191291613d"},
+    {file = "coverage-5.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:be1d89614c6b6c36d7578496dc8625123bda2ff44f224cf8b1c45b810ee7383f"},
+    {file = "coverage-5.0-cp36-cp36m-win32.whl", hash = "sha256:47c81ee687eafc2f1db7f03fbe99aab81330565ebc62fb3b61edfc2216a550c8"},
+    {file = "coverage-5.0-cp36-cp36m-win_amd64.whl", hash = "sha256:3be5338a2eb4ef03c57f20917e1d12a1fd10e3853fed060b6d6b677cb3745898"},
+    {file = "coverage-5.0-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:79388ae29c896299b3567965dbcd93255f175c17c6c7bca38614d12718c47466"},
+    {file = "coverage-5.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:4a7f8e72b18f2aca288ff02255ce32cc830bc04d993efbc87abf6beddc9e56c0"},
+    {file = "coverage-5.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d609a6d564ad3d327e9509846c2c47f170456344521462b469e5cb39e48ba31c"},
+    {file = "coverage-5.0-cp37-cp37m-win32.whl", hash = "sha256:50197163a22fd17f79086e087a787883b3ec9280a509807daf158dfc2a7ded02"},
+    {file = "coverage-5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:b5ed7837b923d1d71c4f587ae1539ccd96bfd6be9788f507dbe94dab5febbb5d"},
+    {file = "coverage-5.0-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c95bb147fab76f2ecde332d972d8f4138b8f2daee6c466af4ff3b4f29bd4c19e"},
+    {file = "coverage-5.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:0cd13a6e98c37b510a2d34c8281d5e1a226aaf9b65b7d770ef03c63169965351"},
+    {file = "coverage-5.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:88d2cbcb0a112f47eef71eb95460b6995da18e6f8ca50c264585abc2c473154b"},
+    {file = "coverage-5.0-cp38-cp38m-win32.whl", hash = "sha256:2ee55e6dba516ddf6f484aa83ccabbb0adf45a18892204c23486938d12258cde"},
+    {file = "coverage-5.0-cp38-cp38m-win_amd64.whl", hash = "sha256:a6d092545e5af53e960465f652e00efbf5357adad177b2630d63978d85e46a72"},
+    {file = "coverage-5.0-cp39-cp39m-win32.whl", hash = "sha256:79fd5d3d62238c4f583b75d48d53cdae759fe04d4fb18fe8b371d88ad2b6f8be"},
+    {file = "coverage-5.0-cp39-cp39m-win_amd64.whl", hash = "sha256:c1b030a79749aa8d1f1486885040114ee56933b15ccfc90049ba266e4aa2139f"},
+    {file = "coverage-5.0.tar.gz", hash = "sha256:e1bad043c12fb58e8c7d92b3d7f2f49977dcb80a08a6d1e7a5114a11bf819fca"},
+]
+cu2qu = [
+    {file = "cu2qu-1.6.6-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:e318a950c61d0a7ae5604843a4c39bfe107486cc51bb3e1010f83475f01931a9"},
+    {file = "cu2qu-1.6.6-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:2eef5a551220a732147eede61e758611044f1cee663333cb7c1f476879fc8cf5"},
+    {file = "cu2qu-1.6.6-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:3c7e92cbf2000e0817d73e7dcc71a015c82c9f97003d2ae149db51717be37cb7"},
+    {file = "cu2qu-1.6.6-cp27-cp27m-win32.whl", hash = "sha256:0c8298e17fd1a508c2d96562d76b099390be4330193551a7c14e966bc327bd2c"},
+    {file = "cu2qu-1.6.6-cp27-cp27m-win_amd64.whl", hash = "sha256:7e20c400b85f1918e5b9a0963dbff96f7dcbd8b59c1c3317f98d45c4765937bb"},
+    {file = "cu2qu-1.6.6-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:38da19d9374427067cf382e76297ec11c5a0a6b8e007425d41a545116c2217cd"},
+    {file = "cu2qu-1.6.6-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:5f8efaf0050b5b0cc4350890e59ac835911238147dbdf4dd09bef865ec4fcf0a"},
+    {file = "cu2qu-1.6.6-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:6466e4398719a9973c80cde510793cb0c3c6d991ca6017f942405d56e23c9dc8"},
+    {file = "cu2qu-1.6.6-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:e03158372c6b54a39b6e0f53c29fd6e9189e392c23ba3d18dd26ed26b1cda5b7"},
+    {file = "cu2qu-1.6.6-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:25c763435f14142c333337fd4c2297ea32d13ff6eb4db8444b02cd9281ee0159"},
+    {file = "cu2qu-1.6.6-cp36-cp36m-win32.whl", hash = "sha256:4cbff5e5c92648492ec34f8b0c7e674a6e0759d1502cb554f29d3b2e6260b2c2"},
+    {file = "cu2qu-1.6.6-cp36-cp36m-win_amd64.whl", hash = "sha256:631c444293759cb32e7a5a1448d0e7f5a3b952934511d0ef2f301391a04a3c8a"},
+    {file = "cu2qu-1.6.6-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:2a842f2e96e28f4bef418f40a1fdb4e424ef3ae84024678a896fbb4d66c77e79"},
+    {file = "cu2qu-1.6.6-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0849d46e7d3d59ddd98083dbbf01071d9e721638d1efcde2a0b502db5ac6e5af"},
+    {file = "cu2qu-1.6.6-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3d2db3b34bcc5a444d811e74ea3635184c4c5fb3745e8976aa7f44c5fc224818"},
+    {file = "cu2qu-1.6.6-cp37-cp37m-win32.whl", hash = "sha256:3ed194eb17c5dd4931ac3ba5b75c4b776e7bc9340498d85a13150d67705fdc58"},
+    {file = "cu2qu-1.6.6-cp37-cp37m-win_amd64.whl", hash = "sha256:4033ae1cc5603b2b95d95df740eacbfa9a14204ef72f873bd671ba0e7596a931"},
+    {file = "cu2qu-1.6.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d5bd0502fd1d8123724e6a9baa13f531d23b05c479ac10ff7baf22aac352e12c"},
+    {file = "cu2qu-1.6.6-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e780a1255fdae6229b8234706059544f2a41b8e4e1f659797d32529d2bd297a6"},
+    {file = "cu2qu-1.6.6-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:dbae3076ac5082f4c31f16dda30a5531b1738ed96135b0f52778cb3798b72fb4"},
+    {file = "cu2qu-1.6.6-cp38-cp38-win32.whl", hash = "sha256:509d043b3ca77f65e06758cd21c78c2edcd6d3de6be3ddc8a2f5772a1da5600d"},
+    {file = "cu2qu-1.6.6-cp38-cp38-win_amd64.whl", hash = "sha256:d238a3efe96b013e681d2e4f08ee185ab7c840035647c06a2b690dabf7b59f77"},
+    {file = "cu2qu-1.6.6.zip", hash = "sha256:06aed734825b35f8a108fcfeb36bc54106689009c9e49f7bed9c07b7cf6692bf"},
+]
+fonttools = [
+    {file = "fonttools-4.2.2-py3-none-any.whl", hash = "sha256:4e5054d33e454b93da666798a440a58f397d2785173c4b9fb634c549e72e1546"},
+    {file = "fonttools-4.2.2.zip", hash = "sha256:66bb3dfe7efe5972b0145339c063ffaf9539e973f7ff8791df84366eafc65804"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-1.3.0-py2.py3-none-any.whl", hash = "sha256:d95141fbfa7ef2ec65cfd945e2af7e5a6ddbd7c8d9a25e66ff3be8e3daf9f60f"},
+    {file = "importlib_metadata-1.3.0.tar.gz", hash = "sha256:073a852570f92da5f744a3472af1b61e28e9f78ccf0c9117658dc32b15de7b45"},
+]
+isort = [
+    {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
+    {file = "isort-4.3.21.tar.gz", hash = "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1"},
+]
+lazy-object-proxy = [
+    {file = "lazy-object-proxy-1.4.3.tar.gz", hash = "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"},
+    {file = "lazy_object_proxy-1.4.3-cp27-cp27m-macosx_10_13_x86_64.whl", hash = "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442"},
+    {file = "lazy_object_proxy-1.4.3-cp27-cp27m-win32.whl", hash = "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4"},
+    {file = "lazy_object_proxy-1.4.3-cp27-cp27m-win_amd64.whl", hash = "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a"},
+    {file = "lazy_object_proxy-1.4.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d"},
+    {file = "lazy_object_proxy-1.4.3-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a"},
+    {file = "lazy_object_proxy-1.4.3-cp34-cp34m-win32.whl", hash = "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e"},
+    {file = "lazy_object_proxy-1.4.3-cp34-cp34m-win_amd64.whl", hash = "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357"},
+    {file = "lazy_object_proxy-1.4.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50"},
+    {file = "lazy_object_proxy-1.4.3-cp35-cp35m-win32.whl", hash = "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db"},
+    {file = "lazy_object_proxy-1.4.3-cp35-cp35m-win_amd64.whl", hash = "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449"},
+    {file = "lazy_object_proxy-1.4.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156"},
+    {file = "lazy_object_proxy-1.4.3-cp36-cp36m-win32.whl", hash = "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531"},
+    {file = "lazy_object_proxy-1.4.3-cp36-cp36m-win_amd64.whl", hash = "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb"},
+    {file = "lazy_object_proxy-1.4.3-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08"},
+    {file = "lazy_object_proxy-1.4.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383"},
+    {file = "lazy_object_proxy-1.4.3-cp37-cp37m-win32.whl", hash = "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142"},
+    {file = "lazy_object_proxy-1.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea"},
+    {file = "lazy_object_proxy-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62"},
+    {file = "lazy_object_proxy-1.4.3-cp38-cp38-win32.whl", hash = "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd"},
+    {file = "lazy_object_proxy-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+more-itertools = [
+    {file = "more-itertools-8.0.2.tar.gz", hash = "sha256:b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d"},
+    {file = "more_itertools-8.0.2-py3-none-any.whl", hash = "sha256:c833ef592a0324bcc6a60e48440da07645063c453880c9477ceb22490aec1564"},
+]
+mypy = [
+    {file = "mypy-0.750-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:de9ec8dba773b78c49e7bec9a35c9b6fc5235682ad1fc2105752ae7c22f4b931"},
+    {file = "mypy-0.750-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:3294821b5840d51a3cd7a2bb63b40fc3f901f6a3cfb3c6046570749c4c7ef279"},
+    {file = "mypy-0.750-cp35-cp35m-win_amd64.whl", hash = "sha256:6992133c95a2847d309b4b0c899d7054adc60481df6f6b52bb7dee3d5fd157f7"},
+    {file = "mypy-0.750-cp36-cp36m-macosx_10_6_x86_64.whl", hash = "sha256:41696a7d912ce16fdc7c141d87e8db5144d4be664a0c699a2b417d393994b0c2"},
+    {file = "mypy-0.750-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:c87ac7233c629f305602f563db07f5221950fe34fe30af072ac838fa85395f78"},
+    {file = "mypy-0.750-cp36-cp36m-win_amd64.whl", hash = "sha256:83fa87f556e60782c0fc3df1b37b7b4a840314ba1ac27f3e1a1e10cb37c89c17"},
+    {file = "mypy-0.750-cp37-cp37m-macosx_10_6_x86_64.whl", hash = "sha256:30e123b24931f02c5d99307406658ac8f9cd6746f0d45a3dcac2fe5fbdd60939"},
+    {file = "mypy-0.750-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:02d9bdd3398b636723ecb6c5cfe9773025a9ab7f34612c1cde5c7f2292e2d768"},
+    {file = "mypy-0.750-cp37-cp37m-win_amd64.whl", hash = "sha256:088f758a50af31cf8b42688118077292370c90c89232c783ba7979f39ea16646"},
+    {file = "mypy-0.750-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4f42675fa278f3913340bb8c3371d191319704437758d7c4a8440346c293ecb2"},
+    {file = "mypy-0.750-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:f385a0accf353ca1bca4bbf473b9d83ed18d923fdb809d3a70a385da23e25b6a"},
+    {file = "mypy-0.750-cp38-cp38-win_amd64.whl", hash = "sha256:54d205ccce6ed930a8a2ccf48404896d456e8b87812e491cb907a355b1a9c640"},
+    {file = "mypy-0.750-py3-none-any.whl", hash = "sha256:28e9fbc96d13397a7ddb7fad7b14f373f91b5cff538e0772e77c270468df083c"},
+    {file = "mypy-0.750.tar.gz", hash = "sha256:6ecbd0e8e371333027abca0922b0c2c632a5b4739a0c61ffbd0733391e39144c"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+packaging = [
+    {file = "packaging-19.2-py2.py3-none-any.whl", hash = "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"},
+    {file = "packaging-19.2.tar.gz", hash = "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47"},
+]
+pluggy = [
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+py = [
+    {file = "py-1.8.0-py2.py3-none-any.whl", hash = "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa"},
+    {file = "py-1.8.0.tar.gz", hash = "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"},
+]
+pyclipper = [
+    {file = "pyclipper-1.1.0.post3-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:6bac42c6fe457065ecb6e8c6e145497d28aaa32d60b8f3be62453e96c0791c81"},
+    {file = "pyclipper-1.1.0.post3-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:41a057cb5009bcdd1278c71d3337eaef46c8ac952d099e7ea7c3a65fad0b6b5f"},
+    {file = "pyclipper-1.1.0.post3-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:c7972d4a0558fa09bc311b5a1169392e7549e13a777d193544c02b56ee299042"},
+    {file = "pyclipper-1.1.0.post3-cp27-cp27m-win32.whl", hash = "sha256:de8602dd431ee7e9302794e5b9e3f6ed3725972787229593445d75aa5f48879c"},
+    {file = "pyclipper-1.1.0.post3-cp27-cp27m-win_amd64.whl", hash = "sha256:541ccf717eb6f6386dc6fd0086eaf50dae919c1f9ff697dc3f9c7047bfbd4ed6"},
+    {file = "pyclipper-1.1.0.post3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:506903b7e0f2f81640354d18be9a5c727872189ad53864b12a9bcc4a75f5ad5d"},
+    {file = "pyclipper-1.1.0.post3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:b7a1cd015d8534ffe15ca8496cf82722b581d386cbdadf2690a8deff319d9df6"},
+    {file = "pyclipper-1.1.0.post3-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:c4de6b8301bf865599009b185f8245436f3e885626478b9b4a22ba8cf8d426a9"},
+    {file = "pyclipper-1.1.0.post3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:9d848cc28229d1a35229801b3a9a184b0f968d5c6185d8a1a4406bb6a3a7659b"},
+    {file = "pyclipper-1.1.0.post3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:55c6efaa83ffd0164c74486e6840fb37c4c3c9478508c44283b8dfb1c861c9c1"},
+    {file = "pyclipper-1.1.0.post3-cp35-cp35m-win32.whl", hash = "sha256:81b2498d2aa96791a51cbd596ea537cbbaae386ee2ab3d2d66cdd99920d374f6"},
+    {file = "pyclipper-1.1.0.post3-cp35-cp35m-win_amd64.whl", hash = "sha256:a8fee90673916c89855ffcea433091f3aa8c77c0f1fa501f5f8b8fd3a4648de2"},
+    {file = "pyclipper-1.1.0.post3-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:b1d5a713e7e890609e4d296b3969d13068a012345434973dcfd4bc6dafede162"},
+    {file = "pyclipper-1.1.0.post3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:1bbb48c7846e24e034c7ef0f44a17ad06f7f8809ac1a54baa341bdb68ad424e4"},
+    {file = "pyclipper-1.1.0.post3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:9a76e9b40b9ffe854a3f07d8daa4025d1fd19776d6263ada1ce434072eca512f"},
+    {file = "pyclipper-1.1.0.post3-cp36-cp36m-win32.whl", hash = "sha256:99824a4921f970ebbe12cdbcaaa4a74dea1e1293c25b8d09209e58b80dbd8b54"},
+    {file = "pyclipper-1.1.0.post3-cp36-cp36m-win_amd64.whl", hash = "sha256:a0d04faf5dc8a66b136e98bfae0c76641257c07a35c49e4f29cde555db17f45f"},
+    {file = "pyclipper-1.1.0.post3-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:a235a01df05eecedfa2b7ee126fb07f9369bc9aa0c67d55a6a8a88585585be40"},
+    {file = "pyclipper-1.1.0.post3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:a868d83afd7018331d614bc393765f6ba20ba4acbebd1bd65983b2d5a9934255"},
+    {file = "pyclipper-1.1.0.post3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ad9d3775b646e227ce8f6e4c9fc2cb9b54cf66cd0b3ee654b804d41e1d422cbb"},
+    {file = "pyclipper-1.1.0.post3-cp37-cp37m-win32.whl", hash = "sha256:adf09f440486c521a248acecaee07d645a4a550b1d346377971108e9d9b87f3f"},
+    {file = "pyclipper-1.1.0.post3-cp37-cp37m-win_amd64.whl", hash = "sha256:0ed486597d318927e975bc6f928763ceb04d6aaf13a094382303722c61ce94cd"},
+    {file = "pyclipper-1.1.0.post3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b91cbead0aa45dfabacdf7cac9c86b6fd4df975c0bf5aa8ccbba95621d25925a"},
+    {file = "pyclipper-1.1.0.post3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b546dcde2eb22f038a2c3f4774d6ad7c9cf6e77335db280025077241191ea2c7"},
+    {file = "pyclipper-1.1.0.post3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:b841e93cca0f46adf677fafb8f1b022711a9367c46ad8dacf489d9a7e573b808"},
+    {file = "pyclipper-1.1.0.post3-cp38-cp38-win32.whl", hash = "sha256:ebc15042d74e01e47fcfcaa4a7fc7c38b3b9b755250215e6e3c71c6eb485f400"},
+    {file = "pyclipper-1.1.0.post3-cp38-cp38-win_amd64.whl", hash = "sha256:96b6a6af0e1e511f5216e0e491448a29802354ce55f572310d15b1936c832d01"},
+    {file = "pyclipper-1.1.0.post3.zip", hash = "sha256:f1acd74bdb8c114fea2eab0bcf76460d1ef4b4120953e410fc7c638eb79e9e98"},
+]
+pylint = [
+    {file = "pylint-2.4.4-py3-none-any.whl", hash = "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"},
+    {file = "pylint-2.4.4.tar.gz", hash = "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd"},
+]
+pyparsing = [
+    {file = "pyparsing-2.4.5-py2.py3-none-any.whl", hash = "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f"},
+    {file = "pyparsing-2.4.5.tar.gz", hash = "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"},
+]
+pytest = [
+    {file = "pytest-5.3.2-py3-none-any.whl", hash = "sha256:e41d489ff43948babd0fad7ad5e49b8735d5d55e26628a58673c39ff61d95de4"},
+    {file = "pytest-5.3.2.tar.gz", hash = "sha256:6b571215b5a790f9b41f19f3531c53a45cf6bb8ef2988bc1ff9afb38270b25fa"},
+]
+pytest-cov = [
+    {file = "pytest-cov-2.8.1.tar.gz", hash = "sha256:cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b"},
+    {file = "pytest_cov-2.8.1-py2.py3-none-any.whl", hash = "sha256:cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"},
+]
+pytest-mypy = [
+    {file = "pytest-mypy-0.4.2.tar.gz", hash = "sha256:5a5338cecff17f005b181546a13e282761754b481225df37f33d37f86ac5b304"},
+    {file = "pytest_mypy-0.4.2-py3-none-any.whl", hash = "sha256:3b7b56912d55439d5f447cc609f91caac7f74f0f1c89f1379d04f06bac777c32"},
+]
+six = [
+    {file = "six-1.13.0-py2.py3-none-any.whl", hash = "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd"},
+    {file = "six-1.13.0.tar.gz", hash = "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"},
+]
+typed-ast = [
+    {file = "typed_ast-1.4.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e"},
+    {file = "typed_ast-1.4.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b"},
+    {file = "typed_ast-1.4.0-cp35-cp35m-win32.whl", hash = "sha256:630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4"},
+    {file = "typed_ast-1.4.0-cp35-cp35m-win_amd64.whl", hash = "sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"},
+    {file = "typed_ast-1.4.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631"},
+    {file = "typed_ast-1.4.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233"},
+    {file = "typed_ast-1.4.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1"},
+    {file = "typed_ast-1.4.0-cp36-cp36m-win32.whl", hash = "sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a"},
+    {file = "typed_ast-1.4.0-cp36-cp36m-win_amd64.whl", hash = "sha256:354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c"},
+    {file = "typed_ast-1.4.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a"},
+    {file = "typed_ast-1.4.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e"},
+    {file = "typed_ast-1.4.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d"},
+    {file = "typed_ast-1.4.0-cp37-cp37m-win32.whl", hash = "sha256:d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36"},
+    {file = "typed_ast-1.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0"},
+    {file = "typed_ast-1.4.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fdc1c9bbf79510b76408840e009ed65958feba92a88833cdceecff93ae8fff66"},
+    {file = "typed_ast-1.4.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:7954560051331d003b4e2b3eb822d9dd2e376fa4f6d98fee32f452f52dd6ebb2"},
+    {file = "typed_ast-1.4.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:48e5b1e71f25cfdef98b013263a88d7145879fbb2d5185f2a0c79fa7ebbeae47"},
+    {file = "typed_ast-1.4.0-cp38-cp38-win32.whl", hash = "sha256:1170afa46a3799e18b4c977777ce137bb53c7485379d9706af8a59f2ea1aa161"},
+    {file = "typed_ast-1.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:838997f4310012cf2e1ad3803bce2f3402e9ffb71ded61b5ee22617b3a7f6b6e"},
+    {file = "typed_ast-1.4.0.tar.gz", hash = "sha256:66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34"},
+]
+typing-extensions = [
+    {file = "typing_extensions-3.7.4.1-py2-none-any.whl", hash = "sha256:910f4656f54de5993ad9304959ce9bb903f90aadc7c67a0bef07e678014e892d"},
+    {file = "typing_extensions-3.7.4.1-py3-none-any.whl", hash = "sha256:cf8b63fedea4d89bab840ecbb93e75578af28f76f66c35889bd7065f5af88575"},
+    {file = "typing_extensions-3.7.4.1.tar.gz", hash = "sha256:091ecc894d5e908ac75209f10d5b4f118fbdb2eb1ede6a63544054bb1edb41f2"},
+]
+ufo2ft = [
+    {file = "ufo2ft-2.11.1-py2.py3-none-any.whl", hash = "sha256:bdde9f94d370cceb405af51a5578e9b29f9014efcfde3219cbeb0d205d4bd76d"},
+    {file = "ufo2ft-2.11.1.zip", hash = "sha256:53f21525c870ca28b88a798b7df31604e44672e27be36e6cae2c58bf3bcdea2a"},
+]
+ufolib2 = [
+    {file = "ufoLib2-0.5.1-py3-none-any.whl", hash = "sha256:6786d2f14213719c12947ebcde9706a38a85630328d14bd3d8bfde1c4cacfa54"},
+    {file = "ufoLib2-0.5.1.zip", hash = "sha256:1ec3c4ac95fceff91b06296ecae2afa8493519c15df97cb203123d05b01ba394"},
+]
+wcwidth = [
+    {file = "wcwidth-0.1.7-py2.py3-none-any.whl", hash = "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"},
+    {file = "wcwidth-0.1.7.tar.gz", hash = "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e"},
+]
+wrapt = [
+    {file = "wrapt-1.11.2.tar.gz", hash = "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"},
+]
+zipp = [
+    {file = "zipp-0.6.0-py2.py3-none-any.whl", hash = "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"},
+    {file = "zipp-0.6.0.tar.gz", hash = "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/daltonmaag/statmake"
 
 [tool.poetry.dependencies]
 attrs = ">= 18.2"
-cattrs = ">= 0.9"
+cattrs = {git = "https://github.com/Tinche/cattrs.git", branch = "bb48897a7f389332d6111a239dcf3bf4a11b526f"}
 fonttools = {version = ">= 3.38", extras = ["ufo"]}
 python = "^3.6"
 


### PR DESCRIPTION
cattrs seems to be dormant currently. There's a fix for Python 3.8 compat in git master, but the maintainer seems not to respond in the issue tracker.