### PR TITLE
Adapt code to use new otlLib builder

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,21 @@
 python_version = 3.6
 platform = linux
 
+# Untyped definitions and calls
+disallow_incomplete_defs = True
+
+# None and Optional handling
+no_implicit_optional = True
+strict_optional = True
+
+# Configuring warnings
+warn_no_return = True
+warn_redundant_casts = True
+warn_unreachable = True
+
+# Miscellaneous strictness flags
+strict_equality = True
+
 [mypy-fontTools.*]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,7 @@ platform = linux
 
 # Untyped definitions and calls
 disallow_incomplete_defs = True
+disallow_untyped_defs = True
 
 # None and Optional handling
 no_implicit_optional = True
@@ -16,6 +17,9 @@ warn_unreachable = True
 
 # Miscellaneous strictness flags
 strict_equality = True
+
+[mypy-tests.*]
+disallow_untyped_defs = False
 
 [mypy-fontTools.*]
 ignore_missing_imports = True

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,5 +1,5 @@
 [[package]]
-category = "dev"
+category = "main"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 name = "appdirs"
 optional = false
@@ -155,6 +155,11 @@ optional = false
 python-versions = ">=3.6"
 version = "4.11.0"
 
+[package.dependencies]
+[package.dependencies.fs]
+optional = true
+version = ">=2.2.0,<3"
+
 [package.extras]
 all = ["fs (>=2.2.0,<3)", "lxml (>=4.0,<5)", "zopfli (>=0.1.4)", "lz4 (>=1.7.4.2)", "matplotlib", "sympy", "brotli (>=1.0.1)", "scipy", "brotlipy (>=0.7.0)", "munkres", "unicodedata2 (>=13.0.0)", "xattr"]
 graphite = ["lz4 (>=1.7.4.2)"]
@@ -166,6 +171,23 @@ type1 = ["xattr"]
 ufo = ["fs (>=2.2.0,<3)"]
 unicode = ["unicodedata2 (>=13.0.0)"]
 woff = ["zopfli (>=0.1.4)", "brotli (>=1.0.1)", "brotlipy (>=0.7.0)"]
+
+[[package]]
+category = "main"
+description = "Python's filesystem abstraction layer"
+name = "fs"
+optional = false
+python-versions = "*"
+version = "2.4.11"
+
+[package.dependencies]
+appdirs = ">=1.4.3,<1.5.0"
+pytz = "*"
+setuptools = "*"
+six = ">=1.10,<2.0"
+
+[package.extras]
+scandir_ = ["scandir (>=1.5,<2.0)"]
 
 [[package]]
 category = "dev"
@@ -352,6 +374,14 @@ checkqa-mypy = ["mypy (v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+category = "main"
+description = "World timezone definitions, modern and historical"
+name = "pytz"
+optional = false
+python-versions = "*"
+version = "2020.1"
+
+[[package]]
 category = "dev"
 description = "Alternative regular expression module, to replace re."
 name = "regex"
@@ -360,7 +390,7 @@ python-versions = "*"
 version = "2020.5.14"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
@@ -435,11 +465,11 @@ lxml = ["lxml"]
 
 [[package]]
 category = "dev"
-description = "Measures number of Terminal column cells of wide-character codes"
+description = "Measures the displayed width of unicode strings in a terminal"
 name = "wcwidth"
 optional = false
 python-versions = "*"
-version = "0.1.9"
+version = "0.2.2"
 
 [[package]]
 category = "dev"
@@ -463,7 +493,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "a70e292e87b027f31e1a1c478bad64f9ee877b8ca371b423cc626d5227ce3dd0"
+content-hash = "354f644f3d6885828ebb741bff0f0a497e9ec8bcfb4817b8d06a6a5f8178d055"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -579,6 +609,10 @@ cu2qu = [
 fonttools = [
     {file = "fonttools-4.11.0-py3-none-any.whl", hash = "sha256:0fa8e29b5f41045eb3d1f867bb78b139e07364dcd850ae5a7a6ecd0520c1cf82"},
     {file = "fonttools-4.11.0.zip", hash = "sha256:7fe5937206099ef284055b8c94798782e0993a740eed87f0dd262ed9870788aa"},
+]
+fs = [
+    {file = "fs-2.4.11-py2.py3-none-any.whl", hash = "sha256:cd6b178f373a0370feac8612fd3c142aa6a5cadd3d471b525b08db4d3b511c9c"},
+    {file = "fs-2.4.11.tar.gz", hash = "sha256:cc99d476b500f993df8ef697b96dc70928ca2946a455c396a566efe021126767"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-1.6.0-py2.py3-none-any.whl", hash = "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f"},
@@ -697,6 +731,10 @@ pytest = [
     {file = "pytest-5.4.2-py3-none-any.whl", hash = "sha256:95c710d0a72d91c13fae35dce195633c929c3792f54125919847fdcdf7caa0d3"},
     {file = "pytest-5.4.2.tar.gz", hash = "sha256:eb2b5e935f6a019317e455b6da83dd8650ac9ffd2ee73a7b657a30873d67a698"},
 ]
+pytz = [
+    {file = "pytz-2020.1-py2.py3-none-any.whl", hash = "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed"},
+    {file = "pytz-2020.1.tar.gz", hash = "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"},
+]
 regex = [
     {file = "regex-2020.5.14-cp27-cp27m-win32.whl", hash = "sha256:e565569fc28e3ba3e475ec344d87ed3cd8ba2d575335359749298a0899fe122e"},
     {file = "regex-2020.5.14-cp27-cp27m-win_amd64.whl", hash = "sha256:d466967ac8e45244b9dfe302bbe5e3337f8dc4dec8d7d10f5e950d83b140d33a"},
@@ -765,8 +803,8 @@ ufolib2 = [
     {file = "ufoLib2-0.7.1.zip", hash = "sha256:0387d3ecae3ffd56f57c81269ef4471981d430888467eaa13220d227bcf3291d"},
 ]
 wcwidth = [
-    {file = "wcwidth-0.1.9-py2.py3-none-any.whl", hash = "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1"},
-    {file = "wcwidth-0.1.9.tar.gz", hash = "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"},
+    {file = "wcwidth-0.2.2-py2.py3-none-any.whl", hash = "sha256:b651b6b081476420e4e9ae61239ac4c1b49d0c5ace42b2e81dc2ff49ed50c566"},
+    {file = "wcwidth-0.2.2.tar.gz", hash = "sha256:3de2e41158cb650b91f9654cbf9a3e053cee0719c9df4ddc11e4b568669e9829"},
 ]
 wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = ["Nikolaus Waxweiler <nikolaus.waxweiler@daltonmaag.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/daltonmaag/statmake"
+include = ["py.typed"]
 
 [tool.poetry.dependencies]
 attrs = ">= 18.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/daltonmaag/statmake"
 [tool.poetry.dependencies]
 attrs = ">= 18.2"
 cattrs = "^1.0"
-fonttools = {version = "^4.0", extras = ["ufo"]}
+fonttools = {version = "^4.11", extras = ["ufo"]}
 python = "^3.6"
 
 [tool.poetry.dev-dependencies]

--- a/src/statmake/__main__.py
+++ b/src/statmake/__main__.py
@@ -1,6 +1,4 @@
-import sys
-
 import statmake.cli
 
 if __name__ == "__main__":
-    sys.exit(statmake.cli.main())
+    statmake.cli.main()

--- a/src/statmake/classes.py
+++ b/src/statmake/classes.py
@@ -164,6 +164,8 @@ class Stylespace:
                 "them and they must be >= 0."
             )
 
+        # XXX: reject locations with axis names not in axes
+
     @classmethod
     def from_dict(cls, dict_data: dict) -> "Stylespace":
         """Construct Stylespace from unstructured dict data."""

--- a/src/statmake/classes.py
+++ b/src/statmake/classes.py
@@ -9,6 +9,8 @@ import cattr
 import fontTools.designspaceLib
 import fontTools.misc.plistlib
 
+from .errors import StylespaceError
+
 DESIGNSPACE_STYLESPACE_INLINE_KEY = "org.statmake.stylespace"
 DESIGNSPACE_STYLESPACE_PATH_KEY = "org.statmake.stylespacePath"
 
@@ -61,7 +63,7 @@ class NameRecord:
             return cls.from_string(data)
         if isinstance(data, dict):
             return cls.from_dict(data)
-        raise ValueError(f"Don't know how to construct NameRecord from '{data}'.")
+        raise StylespaceError(f"Don't know how to construct NameRecord from '{data}'.")
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -87,7 +89,7 @@ class LocationFormat2:
 
     def __attrs_post_init__(self) -> None:
         if len(self.range) != 2:
-            raise ValueError("Range must be a value pair of (min, max).")
+            raise StylespaceError("Range must be a value pair of (min, max).")
 
     def to_builder_dict(self) -> Dict[str, Any]:
         return {
@@ -157,7 +159,7 @@ class Stylespace:
         elif not all(
             isinstance(axis.ordering, int) and axis.ordering >= 0 for axis in self.axes
         ):
-            raise ValueError(
+            raise StylespaceError(
                 "If you specify the ordering for one axis, you must specify all of "
                 "them and they must be >= 0."
             )
@@ -210,7 +212,7 @@ class Stylespace:
         if (stylespace_inline and stylespace_path) or (
             not stylespace_inline and not stylespace_path
         ):
-            raise ValueError(
+            raise StylespaceError(
                 "Designspace lib must contain EITHER inline Stylespace data OR a path "
                 "to an external Stylespace file."
             )
@@ -219,7 +221,7 @@ class Stylespace:
             return cls.from_dict(stylespace_inline)
 
         if not designspace.path:
-            raise ValueError(
+            raise StylespaceError(
                 "Designspace object must have `path` attribute set, because the "
                 "Stylespace path is relative to the Designspace file."
             )

--- a/src/statmake/classes.py
+++ b/src/statmake/classes.py
@@ -145,7 +145,7 @@ class Stylespace:
     locations: List[LocationFormat4] = attr.ib(factory=list)
     elided_fallback_name_id: int = 2
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         """Fill in a default ordering unless the user specified at least one
         custom one.
 

--- a/src/statmake/classes.py
+++ b/src/statmake/classes.py
@@ -2,7 +2,7 @@ import enum
 import functools
 import os
 from pathlib import Path
-from typing import List, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 
 import attr
 import cattr
@@ -70,6 +70,13 @@ class LocationFormat1:
     value: float
     flags: FlagList = attr.ib(factory=FlagList)
 
+    def to_builder_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name.mapping,
+            "value": self.value,
+            "flags": self.flags.value,
+        }
+
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class LocationFormat2:
@@ -82,6 +89,15 @@ class LocationFormat2:
         if len(self.range) != 2:
             raise ValueError("Range must be a value pair of (min, max).")
 
+    def to_builder_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name.mapping,
+            "nominalValue": self.value,
+            "rangeMinValue": self.range[0],
+            "rangeMaxValue": self.range[1],
+            "flags": self.flags.value,
+        }
+
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class LocationFormat3:
@@ -90,12 +106,27 @@ class LocationFormat3:
     linked_value: float
     flags: FlagList = attr.ib(factory=FlagList)
 
+    def to_builder_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name.mapping,
+            "value": self.value,
+            "linkedValue": self.linked_value,
+            "flags": self.flags.value,
+        }
+
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class LocationFormat4:
     name: NameRecord
     axis_values: Mapping[str, float]
     flags: FlagList = attr.ib(factory=FlagList)
+
+    def to_builder_dict(self, name_to_tag: Mapping[str, str]) -> Dict[str, Any]:
+        return {
+            "name": self.name.mapping,
+            "location": {name_to_tag[k]: v for k, v in self.axis_values.items()},
+            "flags": self.flags.value,
+        }
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)

--- a/src/statmake/cli.py
+++ b/src/statmake/cli.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
+from typing import List, Optional
 
 import fontTools.designspaceLib
 import fontTools.ttLib
@@ -10,7 +11,7 @@ import statmake.classes
 import statmake.lib
 
 
-def main(args=None):
+def main(args: Optional[List[str]] = None) -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--stylespace",

--- a/src/statmake/cli.py
+++ b/src/statmake/cli.py
@@ -9,9 +9,12 @@ import fontTools.ttLib
 
 import statmake.classes
 import statmake.lib
+from .errors import Error
 
 
 def main(args: Optional[List[str]] = None) -> None:
+    logging.basicConfig(format="%(levelname)s: %(message)s")
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--stylespace",
@@ -50,7 +53,12 @@ def main(args: Optional[List[str]] = None) -> None:
     additional_locations = designspace.lib.get("org.statmake.additionalLocations", {})
 
     font = fontTools.ttLib.TTFont(parsed_args.variable_font)
-    statmake.lib.apply_stylespace_to_variable_font(
-        stylespace, font, additional_locations
-    )
+    try:
+        statmake.lib.apply_stylespace_to_variable_font(
+            stylespace, font, additional_locations
+        )
+    except Error as e:
+        logging.error("Cannot apply Stylespace to font: %s", str(e))
+        sys.exit(1)
+
     font.save(parsed_args.output_path or parsed_args.variable_font)

--- a/src/statmake/cli.py
+++ b/src/statmake/cli.py
@@ -9,7 +9,7 @@ import fontTools.ttLib
 
 import statmake.classes
 import statmake.lib
-from .errors import Error
+from statmake.errors import Error, StylespaceError
 
 
 def main(args: Optional[List[str]] = None) -> None:
@@ -47,7 +47,7 @@ def main(args: Optional[List[str]] = None) -> None:
     else:
         try:
             stylespace = statmake.classes.Stylespace.from_designspace(designspace)
-        except ValueError as e:
+        except StylespaceError as e:
             logging.error("Could not load Stylespace data from Designspace: %s", str(e))
             sys.exit(1)
     additional_locations = designspace.lib.get("org.statmake.additionalLocations", {})

--- a/src/statmake/errors.py
+++ b/src/statmake/errors.py
@@ -1,2 +1,6 @@
 class Error(Exception):
     """Base exception."""
+
+
+class StylespaceError(Error):
+    """Represents a consistency error in Stylespaces."""

--- a/src/statmake/errors.py
+++ b/src/statmake/errors.py
@@ -1,0 +1,2 @@
+class Error(Exception):
+    """Base exception."""

--- a/src/statmake/lib.py
+++ b/src/statmake/lib.py
@@ -49,6 +49,7 @@ def _generate_builder_data(
             only draw from axes available in the Stylespace.
         4. All name IDs must have a default English (United States) entry for the
             Windows platform, Unicode BMP encoding, to match axis names to tags.
+        5. The font must get a location for every axis the Stylespace contains.
 
     XXX: Enforce that all namerecords must have the same language keys at Stylespace
     instantiation time?

--- a/src/statmake/lib.py
+++ b/src/statmake/lib.py
@@ -5,7 +5,7 @@ import fontTools.otlLib.builder
 import fontTools.ttLib
 
 import statmake.classes
-from .errors import Error
+from statmake.errors import Error
 
 
 def apply_stylespace_to_variable_font(

--- a/src/statmake/lib.py
+++ b/src/statmake/lib.py
@@ -152,8 +152,8 @@ def _sanity_check(
         if stylespace_name_to_tag[name] != tag:
             raise Error(
                 f"Font axis named '{name}' has tag '{tag}' but Stylespace defines it "
-                f"to be {stylespace_name_to_tag[name]}. Axis names and tags must match "
-                "between the font and the Stylespace."
+                f"to be '{stylespace_name_to_tag[name]}'. Axis names and tags must "
+                "match between the font and the Stylespace."
             )
 
     # Sanity check: Ensure the location of the font is fully specified. This means
@@ -166,10 +166,6 @@ def _sanity_check(
             "The location of the font is not fully specified, missing locations "
             f"for the following axes: {missing_axis_names}."
         )
-
-
-def _font_axis_tags(font: fontTools.ttLib.TTFont) -> Set[str]:
-    return {axis.axisTag for axis in font["fvar"].axes}
 
 
 def _default_name_string(otfont: fontTools.ttLib.TTFont, name_id: int) -> str:

--- a/src/statmake/lib.py
+++ b/src/statmake/lib.py
@@ -5,6 +5,7 @@ import fontTools.otlLib.builder
 import fontTools.ttLib
 
 import statmake.classes
+from .errors import Error
 
 
 def apply_stylespace_to_variable_font(
@@ -69,7 +70,7 @@ def _generate_builder_data(
     for instance in varfont["fvar"].instances:
         for k, v in instance.coordinates.items():
             if v not in stylespace_stops[k]:
-                raise ValueError(
+                raise Error(
                     f"There is no Stylespace entry for stop {v} on the '{k}' axis."
                 )
             axis_stops[k].add(v)
@@ -77,7 +78,7 @@ def _generate_builder_data(
     for k, v in additional_locations.items():
         axis_tag = name_to_tag[k]
         if v not in stylespace_stops[axis_tag]:
-            raise ValueError(
+            raise Error(
                 f"There is no Stylespace entry for stop {v} on the '{k}' axis (from "
                 "additional locations)."
             )
@@ -120,7 +121,7 @@ def _sanity_check(
     """Ensures the input data contains no obvious faults."""
 
     if "fvar" not in varfont:
-        raise ValueError(
+        raise Error(
             "Need a variable font with the fvar table to determine which instances "
             "are present."
         )
@@ -131,7 +132,7 @@ def _sanity_check(
     additional_names_set = set(additional_locations.keys())
     if not additional_names_set.issubset(stylespace_names_set):
         surplus_keys = ", ".join(additional_names_set - stylespace_names_set)
-        raise ValueError(
+        raise Error(
             "Additional locations must only contain axis names that are present in "
             f"the Stylespace, the following aren't: {surplus_keys}."
         )
@@ -143,13 +144,13 @@ def _sanity_check(
     }
     for name, tag in font_name_to_tag.items():
         if name not in stylespace_name_to_tag:
-            raise ValueError(
+            raise Error(
                 f"Font contains axis named '{name}' which is not in Stylespace. The "
                 "Stylespace must contain all axes any font from the same family "
                 "contains."
             )
         if stylespace_name_to_tag[name] != tag:
-            raise ValueError(
+            raise Error(
                 f"Font axis named '{name}' has tag '{tag}' but Stylespace defines it "
                 f"to be {stylespace_name_to_tag[name]}. Axis names and tags must match "
                 "between the font and the Stylespace."
@@ -161,7 +162,7 @@ def _sanity_check(
     font_names_set = set(font_name_to_tag.keys()).union(additional_names_set)
     if font_names_set != stylespace_names_set:
         missing_axis_names = ", ".join(stylespace_names_set - font_names_set)
-        raise ValueError(
+        raise Error(
             "The location of the font is not fully specified, missing locations "
             f"for the following axes: {missing_axis_names}"
         )
@@ -175,5 +176,5 @@ def _default_name_string(otfont: fontTools.ttLib.TTFont, name_id: int) -> str:
     """Return English name for name_id."""
     name = otfont["name"].getName(name_id, 3, 1, 0x409)
     if name is None:
-        raise ValueError(f"No English record for id {name_id} for Windows platform.")
+        raise Error(f"No English record for id {name_id} for Windows platform.")
     return name.toStr()

--- a/src/statmake/lib.py
+++ b/src/statmake/lib.py
@@ -1,8 +1,8 @@
 import collections
-from typing import Any, Dict, Mapping, Set, Tuple, List
+from typing import Any, Dict, List, Mapping, Set, Tuple
 
-import fontTools.ttLib
 import fontTools.otlLib.builder
+import fontTools.ttLib
 
 import statmake.classes
 

--- a/src/statmake/lib.py
+++ b/src/statmake/lib.py
@@ -164,7 +164,7 @@ def _sanity_check(
         missing_axis_names = ", ".join(stylespace_names_set - font_names_set)
         raise Error(
             "The location of the font is not fully specified, missing locations "
-            f"for the following axes: {missing_axis_names}"
+            f"for the following axes: {missing_axis_names}."
         )
 
 

--- a/src/statmake/lib.py
+++ b/src/statmake/lib.py
@@ -43,8 +43,11 @@ def _generate_builder_data(
             Every named instance needs a STAT entry for every point of its axis
             definition, i.e. an instance at {"Weight": 300, "Slant": 5} must have a
             Stylespace entry for Weight=300 and for Slant=5.
-        2. The Stylespace must contain all axis tags the varfont does.
-        3. All name IDs must have a default English (United States) entry for the
+        2. The Stylespace must contain all axis names the varfont does and tags must
+            match.
+        3. Additional locations must only specify axes not in the font already and can
+            only draw from axes available in the Stylespace.
+        4. All name IDs must have a default English (United States) entry for the
             Windows platform, Unicode BMP encoding, to match axis names to tags.
 
     XXX: Enforce that all namerecords must have the same language keys at Stylespace
@@ -154,6 +157,15 @@ def _sanity_check(
                 f"Font axis named '{name}' has tag '{tag}' but Stylespace defines it "
                 f"to be '{stylespace_name_to_tag[name]}'. Axis names and tags must "
                 "match between the font and the Stylespace."
+            )
+
+    # Sanity check: Only allow axis names in additional_locations that aren't in the
+    # font already.
+    for axis_name in additional_locations:
+        if axis_name in font_name_to_tag:
+            raise Error(
+                f"Rejecting the additional location for the axis named '{axis_name}' "
+                "because it is already present in the font."
             )
 
     # Sanity check: Ensure the location of the font is fully specified. This means

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,5 +4,5 @@ import pytest
 
 
 @pytest.fixture
-def datadir():
+def datadir() -> Path:
     return Path(__file__).parent / "data"

--- a/tests/data/TestItalIsSlnt.stylespace
+++ b/tests/data/TestItalIsSlnt.stylespace
@@ -1,0 +1,203 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <!-- The top level `axes` key defines a list of axis definitions -->
+    <key>axes</key>
+    <array>
+
+      <!--
+        Each axis definition must have a `name` and the axis `tag` (duplicate
+        the information from the Designspace). `locations` is optional, if you
+        only use format 4 axis values, you don't need to define `locations` on
+        an axis.
+
+        Note that `name` can always be either a string or a dictionary of IETF
+        BCP 47 language codes to name strings. See "Regular" below for how this
+        looks like. If it is a string, it will be used to create a name table
+        entry with it for the language "en" or language ID 0x0409. If it is a
+        dictionary, it will automatically create appropriate multilingual name
+        table entries.
+
+        The `name` of an axis is a special case: You can define a dictionary
+        with name mappings, but it's only going to be used if the axis doesn't
+        already exist in the fvar table. Reason: you can use the `labelname`
+        element in the `axis` element in a Designspace to define multilingual
+        names. You can't when you don't define the axis, so you can do it in
+        the Stylespace instead.
+      -->
+      <dict>
+        <key>name</key>
+        <string>Weight</string>
+        <key>tag</key>
+        <string>wght</string>
+
+        <!--
+          `locations` are a list of dictionaries describing stops on the axis. Each
+          dictionary models one of format 1, 2 and 3 of the STAT axis values.
+        -->
+        <key>locations</key>
+        <array>
+          <!--
+            Format 1 must have at least `name` and `value`. `flags` is optional, see
+            below.
+
+            IMPORTANT: The `value` always means value in user space like in the
+            fvar table!
+          -->
+          <dict>
+            <key>name</key>
+            <string>XLight</string>
+            <key>value</key>
+            <integer>200</integer>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <string>Light</string>
+            <key>value</key>
+            <integer>300</integer>
+          </dict>
+
+          <!--
+            Format 3 must have at least `name`, `value` and `linked_value`. `flags` is
+            optional.
+          -->
+          <dict>
+            <!-- This is an example of how to define multilingual names. -->
+            <key>name</key>
+            <dict>
+              <key>en</key>
+              <string>Regular</string>
+              <key>de</key>
+              <string>Regulär</string>
+            </dict>
+            <key>value</key>
+            <integer>400</integer>
+            <key>linked_value</key>
+            <integer>700</integer>
+            <!--
+              Flags is a list and can contain the strings "ElidableAxisValueName",
+              "OlderSiblingFontAttribute" or both.
+            -->
+            <key>flags</key>
+            <array>
+              <string>ElidableAxisValueName</string>
+            </array>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <string>Semi Bold</string>
+            <key>value</key>
+            <integer>600</integer>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <dict>
+              <key>en</key>
+              <string>Bold</string>
+            </dict>
+            <key>value</key>
+            <integer>700</integer>
+          </dict>
+
+          <!--
+            Format 2 must have at least `name`, `value` and `range` with (min,
+            max) values. `flags` is optional.
+          -->
+          <dict>
+            <key>name</key>
+            <string>Black</string>
+            <key>value</key>
+            <integer>900</integer>
+            <key>range</key>
+            <array>
+              <integer>701</integer>
+              <integer>900</integer>
+            </array>
+          </dict>
+
+        </array>
+      </dict>
+
+      <dict>
+        <key>name</key>
+        <string>Italic</string>
+        <key>tag</key>
+        <string>slnt</string>
+        <key>locations</key>
+        <array>
+
+          <dict>
+            <key>name</key>
+            <string>Upright</string>
+            <key>value</key>
+            <integer>0</integer>
+            <key>linked_value</key>
+            <integer>1</integer>
+            <key>flags</key>
+            <array>
+              <string>ElidableAxisValueName</string>
+            </array>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <string>Italic</string>
+            <key>value</key>
+            <integer>1</integer>
+          </dict>
+
+        </array>
+      </dict>
+    </array>
+
+    <!--
+      The top-level `locations` key is a list of format 4 axis values. It is
+      optional and can be left out from the Stylespace if you don't need format
+      4 axis values.
+
+      ATTENTION: Using format 4 axis values bumps the STAT table version from 1.1 to
+      1.2. At the time of this writing (February 2019), version 1.2 is not supported by
+      Windows.
+    -->
+    <key>locations</key>
+    <array>
+
+      <!--
+        A format 4 dictionary must contain `name` and `axis_values`, the latter
+        is a dictionary of axis names to values. `flags` are optional.
+      -->
+      <dict>
+        <key>name</key>
+        <string>ASDF</string>
+        <key>axis_values</key>
+        <dict>
+          <key>Weight</key>
+          <integer>333</integer>
+          <key>Italic</key>
+          <integer>1</integer>
+        </dict>
+      </dict>
+
+      <dict>
+        <key>name</key>
+        <string>fgfg</string>
+        <key>axis_values</key>
+        <dict>
+          <key>Weight</key>
+          <integer>650</integer>
+          <key>Italic</key>
+          <real>0.5</real>
+        </dict>
+        <key>flags</key>
+        <array>
+          <string>ElidableAxisValueName</string>
+        </array>
+      </dict>
+
+    </array>
+  </dict>
+</plist>

--- a/tests/data/TestJustWght.stylespace
+++ b/tests/data/TestJustWght.stylespace
@@ -1,0 +1,82 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>axes</key>
+    <array>
+
+      <dict>
+        <key>name</key>
+        <string>Weight</string>
+        <key>tag</key>
+        <string>wght</string>
+
+        <key>locations</key>
+        <array>
+          <dict>
+            <key>name</key>
+            <string>XLight</string>
+            <key>value</key>
+            <integer>200</integer>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <string>Light</string>
+            <key>value</key>
+            <integer>300</integer>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <dict>
+              <key>en</key>
+              <string>Regular</string>
+              <key>de</key>
+              <string>Regulär</string>
+            </dict>
+            <key>value</key>
+            <integer>400</integer>
+            <key>linked_value</key>
+            <integer>700</integer>
+            <key>flags</key>
+            <array>
+              <string>ElidableAxisValueName</string>
+            </array>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <string>Semi Bold</string>
+            <key>value</key>
+            <integer>600</integer>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <dict>
+              <key>en</key>
+              <string>Bold</string>
+            </dict>
+            <key>value</key>
+            <integer>700</integer>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <string>Black</string>
+            <key>value</key>
+            <integer>900</integer>
+            <key>range</key>
+            <array>
+              <integer>701</integer>
+              <integer>900</integer>
+            </array>
+          </dict>
+
+        </array>
+      </dict>
+    </array>
+
+  </dict>
+</plist>

--- a/tests/data/TestMultilingual.stylespace
+++ b/tests/data/TestMultilingual.stylespace
@@ -1,0 +1,110 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>axes</key>
+    <array>
+
+      <dict>
+        <key>name</key>
+        <dict>
+          <key>en</key>
+          <string>Weight</string>
+          <key>de</key>
+          <string>Gäwicht</string>
+        </dict>
+        <key>tag</key>
+        <string>wght</string>
+
+        <key>locations</key>
+        <array>
+
+          <dict>
+            <key>name</key>
+            <string>Light</string>
+            <key>value</key>
+            <integer>300</integer>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <dict>
+              <key>en</key>
+              <string>Regular</string>
+              <key>de</key>
+              <string>Regulär</string>
+            </dict>
+            <key>value</key>
+            <integer>400</integer>
+            <key>linked_value</key>
+            <integer>700</integer>
+            <key>flags</key>
+            <array>
+              <string>ElidableAxisValueName</string>
+            </array>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <dict>
+              <key>en</key>
+              <string>Bold</string>
+              <key>fr</key>
+              <string>Bôld</string>
+            </dict>
+            <key>value</key>
+            <integer>700</integer>
+          </dict>
+
+        </array>
+      </dict>
+
+      <dict>
+        <key>name</key>
+        <dict>
+          <key>en</key>
+          <string>Italic</string>
+          <key>de</key>
+          <string>Italienisch</string>
+        </dict>
+        <key>tag</key>
+        <string>ital</string>
+        <key>locations</key>
+        <array>
+
+          <dict>
+            <key>name</key>
+            <dict>
+              <key>en</key>
+              <string>Upright</string>
+              <key>de</key>
+              <string>Aufrecht</string>
+            </dict>
+            <key>value</key>
+            <integer>0</integer>
+            <key>linked_value</key>
+            <integer>1</integer>
+            <key>flags</key>
+            <array>
+              <string>ElidableAxisValueName</string>
+            </array>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <dict>
+              <key>en</key>
+              <string>Italic</string>
+              <key>de</key>
+              <string>Italienisch</string>
+            </dict>
+            <key>value</key>
+            <integer>1</integer>
+          </dict>
+
+        </array>
+      </dict>
+    </array>
+
+  </dict>
+</plist>

--- a/tests/data/Test_WghtItal_Multilingual.designspace
+++ b/tests/data/Test_WghtItal_Multilingual.designspace
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<designspace format="4.0">
+  <axes>
+    <axis default="400" maximum="700" minimum="300" name="Weight" tag="wght">
+      <map input="300" output="0" />
+      <map input="400" output="500" />
+      <map input="700" output="1000" />
+    </axis>
+    <axis default="0" maximum="1" minimum="0" name="Italic" tag="ital"/>
+  </axes>
+
+  <sources>
+    <source filename="master1.ufo" stylename="Extra Light">
+      <info copy="1" />
+      <location>
+        <dimension name="Weight" xvalue="0" />
+        <dimension name="Italic" xvalue="0" />
+      </location>
+    </source>
+    <source filename="master2.ufo" stylename="Black">
+      <location>
+        <dimension name="Weight" xvalue="1000" />
+        <dimension name="Italic" xvalue="0" />
+      </location>
+    </source>
+    <source filename="master1-ital.ufo" stylename="Extra Light Italic">
+      <location>
+        <dimension name="Weight" xvalue="0" />
+        <dimension name="Italic" xvalue="1" />
+      </location>
+    </source>
+    <source filename="master2-ital.ufo" stylename="Black Italic">
+      <location>
+        <dimension name="Weight" xvalue="1000" />
+        <dimension name="Italic" xvalue="1" />
+      </location>
+    </source>
+  </sources>
+
+  <instances>
+    <instance stylename="Light">
+      <location>
+        <dimension name="Weight" xvalue="0" />
+        <dimension name="Italic" xvalue="0" />
+      </location>
+      <kerning />
+      <info />
+    </instance>
+    <instance stylename="Regular">
+      <location>
+        <dimension name="Weight" xvalue="500" />
+        <dimension name="Italic" xvalue="0" />
+      </location>
+      <kerning />
+      <info />
+    </instance>
+    <instance stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="1000" />
+        <dimension name="Italic" xvalue="0" />
+      </location>
+      <kerning />
+      <info />
+    </instance>
+
+    <instance stylename="Light Italic">
+      <location>
+        <dimension name="Weight" xvalue="0" />
+        <dimension name="Italic" xvalue="1" />
+      </location>
+      <kerning />
+      <info />
+    </instance>
+    <instance stylename="Italic">
+      <location>
+        <dimension name="Weight" xvalue="500" />
+        <dimension name="Italic" xvalue="1" />
+      </location>
+      <kerning />
+      <info />
+    </instance>
+    <instance stylename="Bold Italic">
+      <location>
+        <dimension name="Weight" xvalue="1000" />
+        <dimension name="Italic" xvalue="1" />
+      </location>
+      <kerning />
+      <info />
+    </instance>
+
+  </instances>
+</designspace>

--- a/tests/test_make_stat.py
+++ b/tests/test_make_stat.py
@@ -4,17 +4,18 @@ import pytest
 
 import statmake.classes
 import statmake.lib
+from statmake.errors import Error, StylespaceError
 
 from . import testutil
 
 
 def test_load_stylespace_broken_range(datadir):
-    with pytest.raises(ValueError, match=r"Range .*"):
+    with pytest.raises(StylespaceError, match=r"Range .*"):
         statmake.classes.Stylespace.from_file(datadir / "TestBroken.stylespace")
 
 
 def test_load_stylespace_broken_ordering(datadir):
-    with pytest.raises(ValueError, match=r".* ordering .*"):
+    with pytest.raises(StylespaceError, match=r".* ordering .*"):
         statmake.classes.Stylespace.from_file(datadir / "TestBrokenAxes.stylespace")
 
 
@@ -33,12 +34,12 @@ def test_load_from_broken_designspace(datadir):
     designspace = fontTools.designspaceLib.DesignSpaceDocument.fromfile(
         datadir / "TestNoFormat4.stylespace"
     )
-    with pytest.raises(ValueError, match=r".* lib .*"):
+    with pytest.raises(StylespaceError, match=r".* lib .*"):
         statmake.classes.Stylespace.from_designspace(designspace)
 
 
 def test_generation_incomplete_stylespace(datadir):
-    with pytest.raises(ValueError, match=r".* no Stylespace entry .*"):
+    with pytest.raises(Error, match=r".* no Stylespace entry .*"):
         _ = testutil.generate_variable_font(
             datadir / "Test_Wght_Italic.designspace",
             datadir / "TestIncomplete.stylespace",
@@ -47,7 +48,7 @@ def test_generation_incomplete_stylespace(datadir):
 
 def test_generation_incomplete_additional_location(datadir):
     with pytest.raises(
-        ValueError, match=r".* no Stylespace entry .* additional locations.*"
+        Error, match=r".* no Stylespace entry .* additional locations.*"
     ):
         _ = testutil.generate_variable_font(
             datadir / "Test_Wght_Italic.designspace",

--- a/tests/test_make_stat.py
+++ b/tests/test_make_stat.py
@@ -66,6 +66,17 @@ def test_generation_disjunct_additional_location(datadir):
         )
 
 
+def test_generation_superfluous_additional_location(datadir):
+    with pytest.raises(
+        Error, match=r"Rejecting the additional location for the axis named 'Italic'.*"
+    ):
+        _ = testutil.generate_variable_font(
+            datadir / "Test_WghtItal.designspace",
+            datadir / "Test.stylespace",
+            {"Italic": 1},
+        )
+
+
 def test_generation_unknown_font_axis(datadir):
     with pytest.raises(
         Error, match=r"Font contains axis named 'Italic' which is not in Stylespace.*"

--- a/tests/test_make_stat.py
+++ b/tests/test_make_stat.py
@@ -1,4 +1,5 @@
 import fontTools.designspaceLib
+import fontTools.otlLib.builder
 import pytest
 
 import statmake.classes
@@ -147,7 +148,9 @@ def test_generation_full(datadir):
             "Name": {"en": "fgfg"},
         },
     ]
-    assert stat_axis_values == stat_axis_values_expected
+    assert sorted(stat_axis_values, key=lambda x: x["Name"]["en"]) == sorted(
+        stat_axis_values_expected, key=lambda x: x["Name"]["en"]
+    )
 
     assert stat_table.table.ElidedFallbackNameID == 2
 
@@ -308,6 +311,8 @@ def test_generation_italic(datadir):
             "Name": {"en": "ASDF"},
         },
     ]
-    assert stat_axis_values == stat_axis_values_expected
+    assert sorted(stat_axis_values, key=lambda x: x["Name"]["en"]) == sorted(
+        stat_axis_values_expected, key=lambda x: x["Name"]["en"]
+    )
 
     assert stat_table.table.ElidedFallbackNameID == 2

--- a/tests/test_make_stat.py
+++ b/tests/test_make_stat.py
@@ -57,6 +57,47 @@ def test_generation_incomplete_additional_location(datadir):
         )
 
 
+def test_generation_disjunct_additional_location(datadir):
+    with pytest.raises(Error, match=r".* the following aren't: Foo."):
+        _ = testutil.generate_variable_font(
+            datadir / "Test_Wght_Italic.designspace",
+            datadir / "Test.stylespace",
+            {"Foo": 2},
+        )
+
+
+def test_generation_unknown_font_axis(datadir):
+    with pytest.raises(
+        Error, match=r"Font contains axis named 'Italic' which is not in Stylespace.*"
+    ):
+        _ = testutil.generate_variable_font(
+            datadir / "Test_WghtItal.designspace",
+            datadir / "TestJustWght.stylespace",
+            {},
+        )
+
+
+def test_generation_wrong_tag(datadir):
+    with pytest.raises(
+        Error,
+        match=r"Font axis named 'Italic' has tag 'ital' but Stylespace .* 'slnt'.",
+    ):
+        _ = testutil.generate_variable_font(
+            datadir / "Test_WghtItal.designspace",
+            datadir / "TestItalIsSlnt.stylespace",
+            {},
+        )
+
+
+def test_generation_incomplete_location(datadir):
+    with pytest.raises(
+        Error, match=r"missing locations for the following axes: Italic.",
+    ):
+        _ = testutil.generate_variable_font(
+            datadir / "Test_Wght_Italic.designspace", datadir / "Test.stylespace", {},
+        )
+
+
 def test_generation_full(datadir):
     varfont = testutil.generate_variable_font(
         datadir / "Test_WghtItal.designspace", datadir / "Test.stylespace"

--- a/tests/testutil.py
+++ b/tests/testutil.py
@@ -1,6 +1,6 @@
 import io
 from pathlib import Path
-from typing import Mapping
+from typing import Mapping, Optional
 
 import fontTools.designspaceLib
 import fontTools.ttLib
@@ -67,7 +67,7 @@ def dump_name_ids(otfont: fontTools.ttLib.TTFont, name_id: int) -> Mapping[str, 
     return matches
 
 
-def empty_UFO(style_name: str):
+def empty_UFO(style_name: str) -> ufoLib2.Font:
     ufo = ufoLib2.Font()
     ufo.info.familyName = "Test"
     ufo.info.styleName = style_name
@@ -91,7 +91,9 @@ def reload_font(font):
 
 
 def generate_variable_font(
-    designspace_path: Path, stylespace_path: Path, additional_locations=None
+    designspace_path: Path,
+    stylespace_path: Path,
+    additional_locations: Optional[Mapping[str, float]] = None,
 ) -> fontTools.ttLib.TTFont:
     designspace = fontTools.designspaceLib.DesignSpaceDocument.fromfile(
         designspace_path


### PR DESCRIPTION
Make use of https://github.com/fonttools/fonttools/pull/1926 to clean out custom OT table building code.

Also do a lot of other stuff:
- Raise a custom `statmake.errors.Error` instead of generic Python exceptions.
- Enforce all axis names having a default English (United States) entry for the Windows platform, Unicode BMP encoding.
- Limit additional locations to axes in Stylespace and not already in font.
- Enforce the font getting a location for all axes present in Stylespace.

Closes #26.
Closes #13.
Closes #14.
Closes #17 (otlLib does that for us).
 