### PR TITLE
Enforce that all names have a default "en" name and use the same language set

### DIFF
--- a/tests/data/Test.stylespace
+++ b/tests/data/Test.stylespace
@@ -66,12 +66,7 @@
           <dict>
             <!-- This is an example of how to define multilingual names. -->
             <key>name</key>
-            <dict>
-              <key>en</key>
-              <string>Regular</string>
-              <key>de</key>
-              <string>Regulär</string>
-            </dict>
+            <string>Regular</string>
             <key>value</key>
             <integer>400</integer>
             <key>linked_value</key>

--- a/tests/data/TestBogusFormat4.stylespace
+++ b/tests/data/TestBogusFormat4.stylespace
@@ -29,12 +29,7 @@
 
           <dict>
             <key>name</key>
-            <dict>
-              <key>en</key>
-              <string>Regular</string>
-              <key>de</key>
-              <string>Regulär</string>
-            </dict>
+            <string>Regular</string>
             <key>value</key>
             <integer>400</integer>
             <key>linked_value</key>

--- a/tests/data/TestInlineStylespace.designspace
+++ b/tests/data/TestInlineStylespace.designspace
@@ -86,12 +86,7 @@
               </dict>
               <dict>
                 <key>name</key>
-                <dict>
-                  <key>en</key>
-                  <string>Regular</string>
-                  <key>de</key>
-                  <string>Regulär</string>
-                </dict>
+                <string>Regular</string>
                 <key>value</key>
                 <integer>400</integer>
                 <key>linked_value</key>

--- a/tests/data/TestItalIsSlnt.stylespace
+++ b/tests/data/TestItalIsSlnt.stylespace
@@ -66,12 +66,7 @@
           <dict>
             <!-- This is an example of how to define multilingual names. -->
             <key>name</key>
-            <dict>
-              <key>en</key>
-              <string>Regular</string>
-              <key>de</key>
-              <string>Regulär</string>
-            </dict>
+            <string>Regular</string>
             <key>value</key>
             <integer>400</integer>
             <key>linked_value</key>

--- a/tests/data/TestJustWght.stylespace
+++ b/tests/data/TestJustWght.stylespace
@@ -29,12 +29,7 @@
 
           <dict>
             <key>name</key>
-            <dict>
-              <key>en</key>
-              <string>Regular</string>
-              <key>de</key>
-              <string>Regulär</string>
-            </dict>
+            <string>Regular</string>
             <key>value</key>
             <integer>400</integer>
             <key>linked_value</key>

--- a/tests/data/TestMultilingualBrokenAxisNameLang.stylespace
+++ b/tests/data/TestMultilingualBrokenAxisNameLang.stylespace
@@ -7,18 +7,17 @@
 
       <dict>
         <key>name</key>
-        <string>Weight</string>
+        <dict>
+          <key>en</key>
+          <string>Weight</string>
+          <key>de</key>
+          <string>Gäwicht</string>
+        </dict>
         <key>tag</key>
         <string>wght</string>
 
         <key>locations</key>
         <array>
-          <dict>
-            <key>name</key>
-            <string>XLight</string>
-            <key>value</key>
-            <integer>200</integer>
-          </dict>
 
           <dict>
             <key>name</key>
@@ -29,7 +28,12 @@
 
           <dict>
             <key>name</key>
-            <string>Regular</string>
+            <dict>
+              <key>en</key>
+              <string>Regular</string>
+              <key>de</key>
+              <string>Regulär</string>
+            </dict>
             <key>value</key>
             <integer>400</integer>
             <key>linked_value</key>
@@ -42,31 +46,14 @@
 
           <dict>
             <key>name</key>
-            <string>Semi Bold</string>
-            <key>value</key>
-            <integer>600</integer>
-          </dict>
-
-          <dict>
-            <key>name</key>
             <dict>
               <key>en</key>
               <string>Bold</string>
+              <key>fr</key>
+              <string>Bôld</string>
             </dict>
             <key>value</key>
             <integer>700</integer>
-          </dict>
-
-          <dict>
-            <key>name</key>
-            <string>Black</string>
-            <key>value</key>
-            <integer>900</integer>
-            <key>range</key>
-            <array>
-              <integer>701</integer>
-              <integer>900</integer>
-            </array>
           </dict>
 
         </array>
@@ -74,7 +61,12 @@
 
       <dict>
         <key>name</key>
-        <string>Italic</string>
+        <dict>
+          <key>en</key>
+          <string>Italic</string>
+          <key>de</key>
+          <string>Italienisch</string>
+        </dict>
         <key>tag</key>
         <string>ital</string>
         <key>locations</key>
@@ -82,7 +74,12 @@
 
           <dict>
             <key>name</key>
-            <string>Upright</string>
+            <dict>
+              <key>en</key>
+              <string>Upright</string>
+              <key>de</key>
+              <string>Aufrecht</string>
+            </dict>
             <key>value</key>
             <integer>0</integer>
             <key>linked_value</key>
@@ -95,7 +92,12 @@
 
           <dict>
             <key>name</key>
-            <string>Italic</string>
+            <dict>
+              <key>en</key>
+              <string>Italic</string>
+              <key>de</key>
+              <string>Italienisch</string>
+            </dict>
             <key>value</key>
             <integer>1</integer>
           </dict>
@@ -104,20 +106,5 @@
       </dict>
     </array>
 
-    <key>locations</key>
-    <array>
-      <dict>
-        <key>name</key>
-        <string>ASDF</string>
-        <key>axis_values</key>
-        <dict>
-          <key>Weight</key>
-          <integer>333</integer>
-          <key>Fooooo</key>
-          <integer>333</integer>
-        </dict>
-      </dict>
-
-    </array>
   </dict>
 </plist>

--- a/tests/data/TestMultilingualBrokenLocNameLang.stylespace
+++ b/tests/data/TestMultilingualBrokenLocNameLang.stylespace
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>axes</key>
+    <array>
+
+      <dict>
+        <key>name</key>
+        <dict>
+          <key>en</key>
+          <string>Weight</string>
+          <key>de</key>
+          <string>Gäwicht</string>
+        </dict>
+        <key>tag</key>
+        <string>wght</string>
+
+        <key>locations</key>
+        <array>
+
+        </array>
+      </dict>
+
+      <dict>
+        <key>name</key>
+        <dict>
+          <key>en</key>
+          <string>Italic</string>
+          <key>de</key>
+          <string>Italienisch</string>
+        </dict>
+        <key>tag</key>
+        <string>ital</string>
+        <key>locations</key>
+        <array>
+
+          <dict>
+            <key>name</key>
+            <dict>
+              <key>en</key>
+              <string>Upright</string>
+              <key>de</key>
+              <string>Aufrecht</string>
+            </dict>
+            <key>value</key>
+            <integer>0</integer>
+            <key>linked_value</key>
+            <integer>1</integer>
+            <key>flags</key>
+            <array>
+              <string>ElidableAxisValueName</string>
+            </array>
+          </dict>
+
+          <dict>
+            <key>name</key>
+            <dict>
+              <key>en</key>
+              <string>Italic</string>
+            </dict>
+            <key>value</key>
+            <integer>1</integer>
+          </dict>
+
+        </array>
+      </dict>
+    </array>
+
+  </dict>
+</plist>

--- a/tests/data/TestMultilingualNoEn.stylespace
+++ b/tests/data/TestMultilingualNoEn.stylespace
@@ -7,18 +7,15 @@
 
       <dict>
         <key>name</key>
-        <string>Weight</string>
+        <dict>
+          <key>de</key>
+          <string>Gäwicht</string>
+        </dict>
         <key>tag</key>
         <string>wght</string>
 
         <key>locations</key>
         <array>
-          <dict>
-            <key>name</key>
-            <string>XLight</string>
-            <key>value</key>
-            <integer>200</integer>
-          </dict>
 
           <dict>
             <key>name</key>
@@ -29,7 +26,12 @@
 
           <dict>
             <key>name</key>
-            <string>Regular</string>
+            <dict>
+              <key>en</key>
+              <string>Regular</string>
+              <key>de</key>
+              <string>Regulär</string>
+            </dict>
             <key>value</key>
             <integer>400</integer>
             <key>linked_value</key>
@@ -42,31 +44,14 @@
 
           <dict>
             <key>name</key>
-            <string>Semi Bold</string>
-            <key>value</key>
-            <integer>600</integer>
-          </dict>
-
-          <dict>
-            <key>name</key>
             <dict>
               <key>en</key>
               <string>Bold</string>
+              <key>fr</key>
+              <string>Bôld</string>
             </dict>
             <key>value</key>
             <integer>700</integer>
-          </dict>
-
-          <dict>
-            <key>name</key>
-            <string>Black</string>
-            <key>value</key>
-            <integer>900</integer>
-            <key>range</key>
-            <array>
-              <integer>701</integer>
-              <integer>900</integer>
-            </array>
           </dict>
 
         </array>
@@ -74,7 +59,12 @@
 
       <dict>
         <key>name</key>
-        <string>Italic</string>
+        <dict>
+          <key>en</key>
+          <string>Italic</string>
+          <key>de</key>
+          <string>Italienisch</string>
+        </dict>
         <key>tag</key>
         <string>ital</string>
         <key>locations</key>
@@ -82,7 +72,12 @@
 
           <dict>
             <key>name</key>
-            <string>Upright</string>
+            <dict>
+              <key>en</key>
+              <string>Upright</string>
+              <key>de</key>
+              <string>Aufrecht</string>
+            </dict>
             <key>value</key>
             <integer>0</integer>
             <key>linked_value</key>
@@ -95,7 +90,12 @@
 
           <dict>
             <key>name</key>
-            <string>Italic</string>
+            <dict>
+              <key>en</key>
+              <string>Italic</string>
+              <key>de</key>
+              <string>Italienisch</string>
+            </dict>
             <key>value</key>
             <integer>1</integer>
           </dict>
@@ -104,20 +104,5 @@
       </dict>
     </array>
 
-    <key>locations</key>
-    <array>
-      <dict>
-        <key>name</key>
-        <string>ASDF</string>
-        <key>axis_values</key>
-        <dict>
-          <key>Weight</key>
-          <integer>333</integer>
-          <key>Fooooo</key>
-          <integer>333</integer>
-        </dict>
-      </dict>
-
-    </array>
   </dict>
 </plist>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,7 +88,7 @@ TEST_WGHT_UPRIGHT_STAT_DUMP = [
     {"Format": 1, "Name": {"en": "Light"}, "Flags": 0, "AxisIndex": 0, "Value": 300.0},
     {
         "Format": 3,
-        "Name": {"de": "Regulär", "en": "Regular"},
+        "Name": {"en": "Regular"},
         "Flags": 2,
         "AxisIndex": 0,
         "Value": 400.0,

--- a/tests/test_make_stat.py
+++ b/tests/test_make_stat.py
@@ -33,6 +33,31 @@ def test_load_stylespace_broken_format4_2(datadir):
         statmake.classes.Stylespace.from_file(datadir / "TestBogusFormat4_2.stylespace")
 
 
+def test_load_stylespace_broken_multilingual_no_en(datadir):
+    with pytest.raises(StylespaceError, match=r".* must have a default English .*"):
+        statmake.classes.Stylespace.from_file(
+            datadir / "TestMultilingualNoEn.stylespace"
+        )
+
+
+def test_load_stylespace_broken_multilingual_incomplete_lang(datadir):
+    with pytest.raises(
+        StylespaceError, match=r".* languages \['en'\] but expected was \['de', 'en'\]."
+    ):
+        statmake.classes.Stylespace.from_file(
+            datadir / "TestMultilingualBrokenAxisNameLang.stylespace"
+        )
+
+
+def test_load_stylespace_broken_multilingual_incomplete_lang2(datadir):
+    with pytest.raises(
+        StylespaceError, match=r".* languages \['en'\] but expected was \['de', 'en'\]."
+    ):
+        statmake.classes.Stylespace.from_file(
+            datadir / "TestMultilingualBrokenLocNameLang.stylespace"
+        )
+
+
 def test_load_stylespace_no_format4(datadir):
     statmake.classes.Stylespace.from_file(datadir / "TestNoFormat4.stylespace")
 
@@ -161,7 +186,7 @@ def test_generation_full(datadir):
             "Flags": 2,
             "Format": 3,
             "LinkedValue": 700.0,
-            "Name": {"de": "Regulär", "en": "Regular"},
+            "Name": {"en": "Regular"},
             "Value": 400.0,
         },
         {
@@ -260,7 +285,7 @@ def test_generation_upright(datadir):
             "Flags": 2,
             "Format": 3,
             "LinkedValue": 700.0,
-            "Name": {"de": "Regulär", "en": "Regular"},
+            "Name": {"en": "Regular"},
             "Value": 400.0,
         },
         {
@@ -338,7 +363,7 @@ def test_generation_italic(datadir):
             "Flags": 2,
             "Format": 3,
             "LinkedValue": 700.0,
-            "Name": {"de": "Regulär", "en": "Regular"},
+            "Name": {"en": "Regular"},
             "Value": 400.0,
         },
         {


### PR DESCRIPTION
No idea if it even makes sense to have translations just for some names.

The default "en" requirement comes from me having to match axis names to their tags (variable font <-> Stylespace).