### PR TITLE
Relax importlib_metadata dep requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ fonttools = {version = "^4.11", extras = ["ufo"]}
 python = "^3.7"
 
 # https://medium.com/@cjolowicz/hypermodern-python-6-ci-cd-b233accfa2f6#bf20
-importlib_metadata = {version = "^1.6.0", python = "<3.8"}
+importlib_metadata = {version = ">=1.6.0", python = "<3.8"}
 
 [tool.poetry.dev-dependencies]
 black = "^19.10b0"


### PR DESCRIPTION
It can be anything as long as it supports the underlying Python.