### PR TITLE
Make type hint for `Axis.locations` covariant

### DIFF
--- a/src/statmake/classes.py
+++ b/src/statmake/classes.py
@@ -2,7 +2,7 @@ import enum
 import functools
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple, Union
 
 import attrs
 import cattrs
@@ -138,7 +138,7 @@ class LocationFormat4:
 class Axis:
     name: NameRecord
     tag: str
-    locations: List[Union[LocationFormat1, LocationFormat2, LocationFormat3]] = (
+    locations: Sequence[Union[LocationFormat1, LocationFormat2, LocationFormat3]] = (
         attrs.field(factory=list)
     )
 


### PR DESCRIPTION
Previously, something like this would raise a lint issue:

```py
wght = Axis(
    NameRecord.from_string("Weight"),
    "wght", 
    [LocationFormat1(NameRecord.from_string("Light"), 200)],  # 👈 here!
)
```

> Argument of type `list[LocationFormat1]` cannot be assigned to parameter `locations` of type `List[LocationFormat1 | LocationFormat2 | LocationFormat3]` in function `__init__`
>   `list[LocationFormat1]` is not assignable to `List[LocationFormat1 | LocationFormat2 | LocationFormat3]`
>     Type parameter `_T@list` is invariant, but `LocationFormat1` is not the same as `LocationFormat1 | LocationFormat2 | LocationFormat3`
>     Consider switching from `list` to `Sequence` which is covariantPyrightreportArgumentType

This is because `list` isn't covariant. `typing.Sequence` is, thus allowing this code without a lint